### PR TITLE
#49: fault dialog

### DIFF
--- a/NERODesign/content/CriticalFaultIcon.qml
+++ b/NERODesign/content/CriticalFaultIcon.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.15
-import QtQuick.Shapes 1.15
+import QtQuick.Shapes
 
 Item {
     id: critical
@@ -49,6 +49,8 @@ Item {
             width: (critical.dimension/2) * 1.2
             height: (critical.dimension/2) * 1.2
             radius: 100
+
+            visible: numWarnings > 0
 
             Text {
                 id: faultNum

--- a/NERODesign/content/FaultDialog.qml
+++ b/NERODesign/content/FaultDialog.qml
@@ -6,7 +6,7 @@ Window {
     id: faultDialog
     property string faultName: "Oh snap!"
     property string faultMessage: "An error has occurred while creating an error report."
-    property int category: FaultCategory.NonCritical
+    property int category: FaultCategory.Critical
 
     enum FaultCategory {
         Critical,

--- a/NERODesign/content/FaultDialog.qml
+++ b/NERODesign/content/FaultDialog.qml
@@ -1,0 +1,109 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Rectangle {
+    id: faultDialog
+    visible: true
+    property string faultName: "Oh snap!"
+    property string faultMessage: "An error has occurred while creating an error report."
+    property bool isCritical: true
+
+    width: 500
+    height: 400
+    focus: true
+
+    Rectangle {
+        id: rectangle
+        width: parent.width
+        height: parent.height
+        color: "white"
+        radius: 10
+
+        ColumnLayout {
+            id: layout
+            anchors.fill: parent
+
+            CriticalFaultIcon {
+                id: critical
+                visible: isCritical
+                dimension: 50
+                numWarnings: 0
+                Layout.alignment: Qt.AlignHCenter
+                Layout.topMargin: 60
+            }
+
+            NonCriticalWarning {
+                id: nonCritical
+                visible: !isCritical
+                dimension: 50
+                Layout.alignment: Qt.AlignHCenter
+                Layout.topMargin: 60
+                numWarnings: 0
+            }
+
+            Text {
+                id: name
+                text: faultDialog.faultName
+                color: "#4b5c6b"
+                font.pixelSize: 32
+                Layout.alignment: Qt.AlignHCenter
+                horizontalAlignment: Text.AlignHCenter
+                Layout.topMargin: -20
+            }
+
+            Text {
+                id: message
+                text: faultDialog.faultMessage
+                wrapMode: Text.WordWrap
+                color: "#4b5c6b"
+                font.pixelSize: 20
+                Layout.preferredWidth: parent.width * 0.5
+                Layout.alignment: Qt.AlignHCenter
+                horizontalAlignment: Text.AlignHCenter
+                font.weight: Font.Thin
+            }
+
+            Button {
+                id: button
+                Layout.fillWidth: true
+                Layout.preferredHeight: 75
+                flat: true
+                anchors.bottom: parent.bottom
+                anchors.bottomMargin: -6
+
+                Text {
+                    id: dismiss
+                    font.pixelSize: 20
+                    text: "Dismiss"
+                    color: "white"
+                    anchors.centerIn: parent
+                    font.weight: Font.DemiBold
+                }
+
+                background: Rectangle {
+                    radius: 0
+                    color: "#e4615c"
+                }
+                onClicked: closeModal()
+            }
+        }
+    }
+
+    function openModal(name, message) {
+        faultDialog.faultName = name
+        faultDialog.faultMessage = message
+        faultDialog.visible = true
+    }
+
+    function closeModal() {
+        faultDialog.visible = false
+    }
+
+    Keys.onPressed: (event)=> {
+        if (event.key === Qt.Key_Enter)
+            closeModal()
+        if (event.key === Qt.Key_Return)
+            closeModal()
+    }
+}

--- a/NERODesign/content/FaultDialog.qml
+++ b/NERODesign/content/FaultDialog.qml
@@ -1,0 +1,100 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Window {
+    id: faultDialog
+    property string faultName: "Oh snap!"
+    property string faultMessage: "An error has occurred while creating an error report."
+    property int category: FaultCategory.NonCritical
+
+    enum FaultCategory {
+        Critical,
+        NonCritical
+    }
+
+    width: 500
+    height: 400
+    visible: true
+
+    Rectangle {
+        id: rectangle
+        width: parent.width
+        height: parent.height
+        color: "white"
+        radius: 10
+
+        ColumnLayout {
+            id: layout
+            anchors.fill: parent
+
+            CriticalFaultIcon {
+                id: critical
+                visible: faultDialog.category === FaultCategory.Critical
+                dimension: 50
+                numWarnings: 0
+                Layout.alignment: Qt.AlignHCenter
+                Layout.topMargin: 60
+            }
+
+            NonCriticalWarning {
+                id: nonCritical
+                visible: faultDialog.category === FaultCategory.NonCritical
+                dimension: 50
+                Layout.alignment: Qt.AlignHCenter
+                Layout.topMargin: 60
+                numWarnings: 0
+            }
+
+            Text {
+                id: name
+                text: faultDialog.faultName
+                color: "#4b5c6b"
+                font.pixelSize: 32
+                Layout.alignment: Qt.AlignHCenter
+                horizontalAlignment: Text.AlignHCenter
+                Layout.topMargin: -20
+            }
+
+            Text {
+                id: message
+                text: faultDialog.faultMessage
+                wrapMode: Text.WordWrap
+                color: "#4b5c6b"
+                font.pixelSize: 20
+                Layout.preferredWidth: parent.width * 0.5
+                Layout.alignment: Qt.AlignHCenter
+                horizontalAlignment: Text.AlignHCenter
+                font.weight: Font.Thin
+            }
+
+            Button {
+                id: button
+                Layout.fillWidth: true
+                Layout.preferredHeight: 75
+                flat: true
+                anchors.bottom: parent.bottom
+                anchors.bottomMargin: -6
+
+                Text {
+                    id: dismiss
+                    font.pixelSize: 20
+                    text: "Dismiss"
+                    color: "white"
+                    anchors.centerIn: parent
+                    font.weight: Font.DemiBold
+                }
+
+                background: Rectangle {
+                    radius: 0
+                    color: "#e4615c"
+                }
+                onClicked: faultDialog.visible = false
+            }
+        }
+    }
+
+    Keys.onReturnPressed: {
+        faultDialog.visible = false;
+    }
+}

--- a/NERODesign/content/NonCriticalWarning.qml
+++ b/NERODesign/content/NonCriticalWarning.qml
@@ -40,6 +40,7 @@ Item {
             width: dimension / 2
             height: dimension / 2
             color: "#ffffff"
+            visible: numWarnings > 0
 
             Text {
                 id: number

--- a/NERODesign/content/NonCriticalWarning.qml
+++ b/NERODesign/content/NonCriticalWarning.qml
@@ -41,6 +41,8 @@ Item {
             height: dimension / 2
             color: "#ffffff"
 
+            visible: numWarnings > 0
+
             Text {
                 id: number
                 text: numWarnings


### PR DESCRIPTION
## Changes

Created a Fault Dialog, modified NonCriticalWarning.qml to display no circle when numWarnings = 0

## Screenshots

![image](https://github.com/Northeastern-Electric-Racing/Nero-2.0/assets/26651751/2c2a8a83-0997-481a-8359-b3140c2aaf0d)


## To Do

_Any remaining things that need to get done_

- [ ] fix NonCritical icon not hiding when category is Critical
- [ ] fix Critical icon not showing up/crashing QT

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #49
