### PR TITLE
#48 arrange header view

### DIFF
--- a/NERODesign/content/CriticalFaultIcon.qml
+++ b/NERODesign/content/CriticalFaultIcon.qml
@@ -50,6 +50,8 @@ Item {
             height: (critical.dimension/2) * 1.2
             radius: 100
 
+            visible: numWarnings > 0
+
             Text {
                 id: faultNum
                 anchors.centerIn: parent

--- a/NERODesign/content/HeaderView.qml
+++ b/NERODesign/content/HeaderView.qml
@@ -11,17 +11,18 @@ Item {
         width: 70
         height: 70
         anchors.right: parent.right
-        anchors.top: parent.topRight
+        anchors.top: parent.top
+        anchors.rightMargin: microphoneComponent.width / 10
+        anchors.topMargin: microphoneComponent.height / 10
     }
 
     NonCriticalWarning {
         id: nonCriticalWarning
-        width: 70
-        height: 70
         anchors.left: parent.left
-        anchors.top: parent.topLeft
+        anchors.top: parent.top
         dimension: 70
-
+        anchors.leftMargin: nonCriticalWarning.width / 10
+        anchors.topMargin: nonCriticalWarning.height / 10
     }
 
     CriticalFaultIcon {
@@ -30,6 +31,6 @@ Item {
         height: 70
         anchors.left: nonCriticalWarning.right
         anchors.top: parent.top
+        anchors.topMargin: criticalFaultIcon.height / 10
     }
-
 }

--- a/NERODesign/content/HeaderView.qml
+++ b/NERODesign/content/HeaderView.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import NERO
 
 Item {
     width: 800

--- a/NERODesign/content/HeaderView.qml
+++ b/NERODesign/content/HeaderView.qml
@@ -8,33 +8,28 @@ Item {
 
     MicrophoneComponent {
         id: microphoneComponent
-        width: 100
-        height: 100
+        width: 70
+        height: 70
         anchors.right: parent.right
-        anchors.top: parent.top
+        anchors.top: parent.topRight
     }
 
     NonCriticalWarning {
         id: nonCriticalWarning
-        width: 100
-        height: 100
-        anchors.right: parent.right
-        anchors.verticalCenterOffset: -84
-        anchors.verticalCenter: parent.verticalCenter
+        width: 70
+        height: 70
+        anchors.left: parent.left
+        anchors.top: parent.topLeft
         dimension: 70
 
     }
 
     CriticalFaultIcon {
         id: criticalFaultIcon
-        x: 700
-        y: 230
         width: 70
         height: 70
-        anchors.right: parent.right
-        anchors.rightMargin: 15
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.verticalCenterOffset: 15
+        anchors.left: nonCriticalWarning.right
+        anchors.top: parent.top
     }
 
 }

--- a/NERODesign/content/HeaderView.qml
+++ b/NERODesign/content/HeaderView.qml
@@ -1,0 +1,39 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    width: 800
+    height: 480
+
+    MicrophoneComponent {
+        id: microphoneComponent
+        width: 100
+        height: 100
+        anchors.right: parent.right
+        anchors.top: parent.top
+    }
+
+    NonCriticalWarning {
+        id: nonCriticalWarning
+        width: 100
+        height: 100
+        anchors.right: parent.right
+        anchors.verticalCenterOffset: -84
+        anchors.verticalCenter: parent.verticalCenter
+        dimension: 70
+
+    }
+
+    CriticalFaultIcon {
+        id: criticalFaultIcon
+        x: 700
+        y: 230
+        width: 70
+        height: 70
+        anchors.right: parent.right
+        anchors.rightMargin: 15
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.verticalCenterOffset: 15
+    }
+
+}

--- a/NERODesign/content/HeaderView.qml
+++ b/NERODesign/content/HeaderView.qml
@@ -4,7 +4,7 @@ import NERO
 
 Item {
     width: 800
-    height: 480
+    height: 100
 
     MicrophoneComponent {
         id: microphoneComponent
@@ -20,17 +20,21 @@ Item {
         id: nonCriticalWarning
         anchors.left: parent.left
         anchors.top: parent.top
-        dimension: 70
+        dimension: 45
         anchors.leftMargin: nonCriticalWarning.width / 10
         anchors.topMargin: nonCriticalWarning.height / 10
     }
 
     CriticalFaultIcon {
         id: criticalFaultIcon
+        //dimension: 45
         width: 70
         height: 70
+        visible: true
         anchors.left: nonCriticalWarning.right
         anchors.top: parent.top
         anchors.topMargin: criticalFaultIcon.height / 10
+        dimension: 20
     }
+
 }

--- a/NERODesign/content/HeaderView.qml
+++ b/NERODesign/content/HeaderView.qml
@@ -3,8 +3,13 @@ import QtQuick.Controls 2.15
 import NERO
 
 Item {
+    id: header
     width: 800
     height: 100
+
+    property int numCriticalWarnings: 0
+    property int numNonCriticalWarnings: 0
+    property bool isTalking: false
 
     MicrophoneComponent {
         id: microphoneComponent

--- a/NERODesign/content/HeaderView.qml
+++ b/NERODesign/content/HeaderView.qml
@@ -28,13 +28,13 @@ Item {
     CriticalFaultIcon {
         id: criticalFaultIcon
         //dimension: 45
-        width: 70
-        height: 70
+        //width: 70
+        //height: 70
         visible: true
         anchors.left: nonCriticalWarning.right
         anchors.top: parent.top
         anchors.topMargin: criticalFaultIcon.height / 10
-        dimension: 20
+        dimension: 70
     }
 
 }

--- a/NERODesign/content/Pit.qml
+++ b/NERODesign/content/Pit.qml
@@ -18,15 +18,6 @@ Item {
     property int labelVerticalSpacing: 10
     property bool isTalking: false
 
-    MicrophoneComponent {
-        id: microphoneComponent
-        anchors.right: pit.right
-        anchors.top: pit.top
-        width: 100
-        height: 70
-        isTalking: pit.isTalking
-    }
-
     Row {
         id: mainRow
         width: parent.width - horizontalMargin * 2

--- a/NERODevelopment/src/main.cpp
+++ b/NERODevelopment/src/main.cpp
@@ -40,6 +40,7 @@ int main(int argc, char *argv[]) {
 
   engine.rootContext()->setContextProperty("model", model);
   engine.rootContext()->setContextProperty("homeController", &homeController);
+  engine.rootContext()->setContextProperty("headerController", &headerController);
 
   engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
 

--- a/NERODevelopment/src/main.cpp
+++ b/NERODevelopment/src/main.cpp
@@ -25,6 +25,7 @@ int main(int argc, char *argv[]) {
   model->moveToThread(dataThread);
 
   HomeController homeController(model);
+  HeaderController headerController(model);
 
   dataThread->start();
 


### PR DESCRIPTION
## Changes
changed icons to match screenshot

## Screenshots
<img width="287" alt="image" src="https://github.com/Northeastern-Electric-Racing/Nero-2.0/assets/76697442/7534870f-5d36-4907-8958-a61341d31907">



Closes issue #48 
