### PR TITLE
#138 pit screen redesign

### DIFF
--- a/NERODevelopment/content/DirectionView.qml
+++ b/NERODevelopment/content/DirectionView.qml
@@ -16,19 +16,19 @@ Item {
 
         Rectangle {
             id: rectangle
-            color: forward ? "#7CFC00" : "transparent"
+            color: forward ? "#55AAFF" : "transparent"
             Layout.fillHeight: true
-            Layout.preferredWidth: parent.width/2 - 10
+            Layout.preferredWidth: parent.width / 2 - 20
             border.color: forward ? "transparent" : "white"  // Outline color
-            border.width: 5      // Outline width
+            border.width: 2      // Outline width
             radius: directionView.radius          // Border radius to round the corners
 
 
             Text {
                 anchors.centerIn: parent
-                font.pixelSize: Math.min(parent.width, parent.height)
+                font.pixelSize: Math.min(parent.width, parent.height) / 1.5
                 text: "D"
-                color: "white"
+                color: "black"
                 font.family: webFont.name
             }
         }
@@ -38,13 +38,13 @@ Item {
             color: forward ? "transparent" : "Red"
             Layout.fillHeight: true
             Layout.preferredWidth: parent.width / 2 - 20
-            border.color: forward ? "white" : "transparent"  // Outline color
-            border.width: 5      // Outline width
+            border.color: forward ? "#55AAFF" : "transparent"  // Outline color
+            border.width: 2      // Outline width
             radius: directionView.radius          // Border radius to round the corners
 
             Text {
                 anchors.centerIn: parent
-                font.pixelSize: Math.min(parent.width, parent.height)
+                font.pixelSize: Math.min(parent.width, parent.height) / 1.5
                 color: "white"
                 font.family: webFont.name
                 text: "R"

--- a/NERODevelopment/content/LabeledComponent.qml
+++ b/NERODevelopment/content/LabeledComponent.qml
@@ -80,7 +80,7 @@ Rectangle {
             anchors.left: valueText.right
             anchors.top: parent.top
             color: "#777777"
-            font.pixelSize: labelComponent.valueFontSize
+            font.pixelSize: 54
         }
     }
 }

--- a/NERODevelopment/content/LabeledComponent.qml
+++ b/NERODevelopment/content/LabeledComponent.qml
@@ -80,7 +80,7 @@ Rectangle {
             anchors.left: valueText.right
             anchors.top: parent.top
             color: "#777777"
-            font.pixelSize: 54
+            font.pixelSize: labelComponent.valueFontSize
         }
     }
 }

--- a/NERODevelopment/content/Pit.qml
+++ b/NERODevelopment/content/Pit.qml
@@ -8,201 +8,125 @@ Rectangle {
     id: pit
     anchors.fill: parent
     property int stateOfChargePercentage: homeController.stateOfCharge
+    property int lvStateOfChargePercentage: homeController.lowVoltageStateOfCharge
     property int packTempValue: homeController.packTemp
     property int motorTempValue: homeController.motorTemp
     property int currentSpeed: homeController.speed
     property bool forward: homeController.status
-    property int hvSOC: efficiencyController.stateOfCharge
-    property int lvSOC: efficiencyController.lowVoltageStateOfCharge
 
     property int maxSpeed: 5
-    property int horizontalMargin: 10
-    property int horizontalIconSpacing: -55
-    property int iconWidth: 40
-    property int iconHeight: 90
-    property int labelVerticalSpacing: 10
+    property int horizontalMargin: 40
+    property int componentRadii: 20
+    property int bottomMargin: 40
+    property int valueFontSize: Math.min(height / 8, width / 8)
+    property int labelFontSize: Math.min(height / 20, width / 20)
+
     color: 'black'
     height: 480
     width: 800
-
-    Rectangle {
-        id: mainRow
-        anchors.fill: parent
-        anchors.leftMargin: 12
-        anchors.rightMargin: 8
-        anchors.topMargin: 0
-        anchors.bottomMargin: 0
-        color: "transparent"
-
-        Rectangle {
-            id: coreInfoLeft
-            anchors.left: parent.left
-            anchors.top: parent.top
-            anchors.topMargin: 100
-            anchors.bottomMargin: 20
-            anchors.bottom: parent.bottom
-            width: parent.width / 2
-            color: "transparent"
-
-            Rectangle {
-                id: topLeft
-                anchors.top: parent.top
-                anchors.right: parent.right
-                anchors.left: parent.left
-                height: parent.height / 2
-                color: "transparent"
-
-                ThermometerValueComponent {
-                    anchors.top: parent.top
-                    anchors.left: parent.left
-                    anchors.bottom: parent.bottom
-                    width: parent.width / 1.75
-                    radius: 25
-                    thermometerValue: pit.motorTempValue
-                    title: "MOTOR TEMP"
-                }
-            }
-
-            Rectangle {
-                id: bottomLeft
-                anchors.top: topLeft.bottom
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.bottom: parent.bottom
-                color: "transparent"
-
-                ThermometerValueComponent {
-                    id: packTempThermometer
-                    anchors.left: parent.left
-                    anchors.top: parent.top
-                    anchors.bottom: parent.bottom
-                    width: parent.width / 1.75
-                    radius: 25
-                    thermometerValue: pit.packTempValue
-                    title: "PACK TEMP"
-                }
-            }
-        }
-
-        Rectangle {
-            id: coreInfoRight
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.topMargin: 100
-            anchors.bottomMargin: 20
-            anchors.bottom: parent.bottom
-            width: parent.width / 2
-            color: "transparent"
-
-            Rectangle {
-                id: topRight
-                anchors.top: parent.top
-                anchors.right: parent.right
-                anchors.left: parent.left
-                height: parent.height / 2
-                color: "transparent"
-
-                BatteryValueComponent {
-                    id: hvSocBattery
-                    anchors.top: parent.top
-                    anchors.right: parent.right
-                    anchors.bottom: parent.bottom
-                    width: parent.width / 1.75
-                    radius: 25
-                    batteryValue: hvSOC
-                    title: "HV SOC"
-                }
-            }
-
-            Rectangle {
-                id: bottomRight
-                anchors.top: topRight.bottom
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.bottom: parent.bottom
-                color: "transparent"
-
-                BatteryValueComponent {
-                    id: lvSocBattery
-                    anchors.top: parent.top
-                    anchors.right: parent.right
-                    anchors.bottom: parent.bottom
-                    width: parent.width / 1.75
-                    radius: 25
-                    batteryValue: lvSOC
-                    title: "LV SOC"
-                }
-            }
-        }
-
-        ColumnLayout {
-            id: speedometerColumn
-            height: parent.height - 30
-            anchors.centerIn: mainRow
-
-            Radial {
-                id: speedometer
-                Layout.preferredWidth: 350
-                Layout.preferredHeight: 250
-                value: pit.currentSpeed
-                maxValue: pit.maxSpeed
-                valueFontSize: width / 5
-                verticalPadding: 75
-                anchors.centerIn: parent
-            }
-
-            DirectionView {
-                id: directionView
-                forward: forward
-                Layout.preferredWidth: 200
-                Layout.preferredHeight: 75
-                radius: 10
-                anchors.bottom: parent.bottom
-                anchors.horizontalCenter: parent.horizontalCenter
-            }
-        }
-    }
 
     HeaderView {
         id: headerView
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
-        height: 75
+        height: 100
+    }
 
-        RowLayout {
-                anchors.centerIn: parent
-                spacing: 10
+    RowLayout {
+        id: mainRow
+        anchors {
+            leftMargin: pit.horizontalMargin
+            rightMargin: pit.horizontalMargin
+            topMargin: 0
+            bottomMargin: pit.bottomMargin
+            top: headerView.bottom
+            left: parent.left
+            right: parent.right
+            bottom: parent.bottom
+        }
+        spacing: parent.width / 20
 
-                Text {
-                    text: "CAR ON"
-                    color: "#00FF00"
-                    font {
-                        pixelSize: 36
-                        bold: true
-                    }
-                    Layout.alignment: Qt.AlignVCenter
-                }
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.preferredWidth: 5
+            spacing: parent.height / 20
 
-                Text {
-                    text: "-"
-                    color: "white"
-                    font {
-                        pixelSize: 36
-                        bold: true
-                    }
-                    Layout.alignment: Qt.AlignVCenter
-                }
-
-                Text {
-                    text: "GLVMS OFF"
-                    color: "#FF0000"
-                    font {
-                        pixelSize: 36
-                        bold: true
-                    }
-                    Layout.alignment: Qt.AlignVCenter
-                }
+            ThermometerValueComponent {
+                thermometerValue: pit.motorTempValue
+                title: 'MOTOR TEMP'
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                radius: pit.componentRadii
+                valueFontSize: pit.valueFontSize
+                labelFontSize: pit.labelFontSize
             }
+
+            ThermometerValueComponent {
+                thermometerValue: pit.packTempValue
+                title: 'PACK TEMP'
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                radius: pit.componentRadii
+                valueFontSize: pit.valueFontSize
+                labelFontSize: pit.labelFontSize
+            }
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.preferredWidth: 6
+            spacing: parent.height / 20
+
+            Radial {
+                value: pit.currentSpeed
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.preferredHeight: 3
+                valueFontSize: pit.valueFontSize
+                maxValue: pit.maxSpeed
+            }
+
+            DirectionView {
+                forward: pit.forward
+                radius: 10
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.preferredHeight: 1
+                Layout.leftMargin: 20
+                Layout.rightMargin: 20
+            }
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.preferredWidth: 5
+            spacing: parent.height / 20
+
+            BatteryValueComponent {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+
+                batteryValue: pit.stateOfChargePercentage
+                title: "HV SOC"
+                radius: pit.componentRadii
+                valueFontSize: pit.valueFontSize
+                labelFontSize: pit.labelFontSize
+            }
+
+            BatteryValueComponent {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+
+                batteryValue: pit.lvStateOfChargePercentage
+                title: "LV SOC"
+                radius: pit.componentRadii
+                valueFontSize: pit.valueFontSize
+                labelFontSize: pit.labelFontSize
+            }
+        }
     }
 }

--- a/NERODevelopment/content/Pit.qml
+++ b/NERODevelopment/content/Pit.qml
@@ -12,6 +12,8 @@ Rectangle {
     property int motorTempValue: homeController.motorTemp
     property int currentSpeed: homeController.speed
     property bool forward: homeController.status
+    property int hvSOC: efficiencyController.stateOfCharge
+    property int lvSOC: efficiencyController.lowVoltageStateOfCharge
 
     property int maxSpeed: 5
     property int horizontalMargin: 10
@@ -33,7 +35,7 @@ Rectangle {
         color: "transparent"
 
         Rectangle {
-            id: coreInfo
+            id: coreInfoLeft
             anchors.left: parent.left
             anchors.top: parent.top
             anchors.topMargin: 100
@@ -43,7 +45,7 @@ Rectangle {
             color: "transparent"
 
             Rectangle {
-                id: topRow
+                id: topLeft
                 anchors.top: parent.top
                 anchors.right: parent.right
                 anchors.left: parent.left
@@ -51,92 +53,113 @@ Rectangle {
                 color: "transparent"
 
                 ThermometerValueComponent {
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.bottom: parent.bottom
+                    width: parent.width / 1.75
+                    radius: 25
+                    thermometerValue: pit.motorTempValue
+                    title: "MOTOR TEMP"
+                }
+            }
+
+            Rectangle {
+                id: bottomLeft
+                anchors.top: topLeft.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                color: "transparent"
+
+                ThermometerValueComponent {
                     id: packTempThermometer
                     anchors.left: parent.left
                     anchors.top: parent.top
                     anchors.bottom: parent.bottom
-                    width: parent.width / 2
-
+                    width: parent.width / 1.75
+                    radius: 25
+                    //thermometerColor: "blue"
                     thermometerValue: pit.packTempValue
                     title: "PACK TEMP"
                 }
+            }
+        }
 
-                ColumnLayout {
+        Rectangle {
+            id: coreInfoRight
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.topMargin: 100
+            anchors.bottomMargin: 20
+            anchors.bottom: parent.bottom
+            width: parent.width / 2
+            color: "transparent"
+
+            Rectangle {
+                id: topRight
+                anchors.top: parent.top
+                anchors.right: parent.right
+                anchors.left: parent.left
+                height: parent.height / 2
+                color: "transparent"
+
+                BatteryValueComponent {
+                    id: hvSocBattery
                     anchors.top: parent.top
-                    anchors.bottom: parent.bottom
                     anchors.right: parent.right
-                    anchors.bottomMargin: 19
-                    anchors.topMargin: 18
-                    width: parent.width / 2
-
-                    ValueText {
-                        text: pit.maxSpeed
-                        Layout.alignment: Qt.AlignHCenter
-                        font.pixelSize: 0.6 * parent.height
-                    }
-
-                    LabelText {
-                        text: "SPEED LIMIT"
-                        Layout.alignment: Qt.AlignHCenter
-                        font.pixelSize: 0.15 * parent.width
-                    }
+                    anchors.bottom: parent.bottom
+                    width: parent.width / 1.75
+                    radius: 25
+                    batteryValue: hvSOC
+                    title: "HV SOC"
                 }
             }
+
             Rectangle {
-                id: bottomRow
-                anchors.top: topRow.bottom
+                id: bottomRight
+                anchors.top: topRight.bottom
                 anchors.left: parent.left
                 anchors.right: parent.right
                 anchors.bottom: parent.bottom
                 color: "transparent"
 
                 BatteryValueComponent {
-                    id: battery
+                    id: lvSocBattery
                     anchors.top: parent.top
-                    anchors.left: parent.left
-                    anchors.bottom: parent.bottom
-                    anchors.bottomMargin: 22
-
-                    width: parent.width / 2
-                    title: "PACK SOC"
-                    batteryValue: pit.stateOfChargePercentage
-                }
-
-                ThermometerValueComponent {
-                    anchors.top: parent.top
-                    anchors.left: battery.right
                     anchors.right: parent.right
                     anchors.bottom: parent.bottom
-
-                    thermometerValue: pit.motorTempValue
-                    title: "MOTOR TEMP"
+                    width: parent.width / 1.75
+                    radius: 25
+                    batteryValue: lvSOC
+                    title: "LV SOC"
                 }
             }
         }
 
         ColumnLayout {
-            id: spedometerColumn
-            anchors.left: coreInfo.right
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
+            id: speedometerColumn
+            height: parent.height - 30
+            anchors.centerIn: mainRow
 
             Radial {
-                id: spedometer
-                Layout.preferredWidth: 400
-                Layout.preferredHeight: 300
+                id: speedometer
+                Layout.preferredWidth: 350
+                Layout.preferredHeight: 250
                 value: pit.currentSpeed
                 maxValue: pit.maxSpeed
-                Layout.alignment: Qt.AlignHCenter
+                valueFontSize: width / 5
+                verticalPadding: 75
+                anchors.centerIn: parent
             }
 
             DirectionView {
                 id: directionView
                 forward: forward
-                Layout.preferredWidth: 300
-                Layout.preferredHeight: 100
+                Layout.preferredWidth: 200
+                Layout.preferredHeight: 75
                 radius: 10
-                Layout.alignment: Qt.AlignHCenter
+                anchors.bottom: parent.bottom
+                anchors.horizontalCenter: parent.horizontalCenter
             }
         }
     }
@@ -146,6 +169,41 @@ Rectangle {
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
-        height: 100
+        height: 75
+
+        RowLayout {
+                anchors.centerIn: parent
+                spacing: 10
+
+                Text {
+                    text: "CAR ON"
+                    color: "#00FF00"
+                    font {
+                        pixelSize: 36
+                        bold: true
+                    }
+                    Layout.alignment: Qt.AlignVCenter
+                }
+
+                Text {
+                    text: "-"
+                    color: "white"
+                    font {
+                        pixelSize: 36
+                        bold: true
+                    }
+                    Layout.alignment: Qt.AlignVCenter
+                }
+
+                Text {
+                    text: "GLVMS OFF"
+                    color: "#FF0000"
+                    font {
+                        pixelSize: 36
+                        bold: true
+                    }
+                    Layout.alignment: Qt.AlignVCenter
+                }
+            }
     }
 }

--- a/NERODevelopment/content/Pit.qml
+++ b/NERODevelopment/content/Pit.qml
@@ -78,7 +78,6 @@ Rectangle {
                     anchors.bottom: parent.bottom
                     width: parent.width / 1.75
                     radius: 25
-                    //thermometerColor: "blue"
                     thermometerValue: pit.packTempValue
                     title: "PACK TEMP"
                 }

--- a/NERODevelopment/src/controllers/homecontroller.cpp
+++ b/NERODevelopment/src/controllers/homecontroller.cpp
@@ -53,12 +53,23 @@ void HomeController::setMotorTemp(float motorTemp) {
   }
 }
 
-float HomeController::stateOfCharge() const { return m_stateOfCharge; }
+int HomeController::stateOfCharge() const { return m_stateOfCharge; }
 
-void HomeController::setStateOfCharge(float stateOfCharge) {
-  if (m_stateOfCharge != stateOfCharge) {
-    m_stateOfCharge = stateOfCharge;
-    emit stateOfChargeChanged(stateOfCharge);
+void HomeController::setStateOfCharge(int charge) {
+  if (charge != m_stateOfCharge) {
+    m_stateOfCharge = charge;
+    emit stateOfChargeChanged(charge);
+  }
+}
+
+int HomeController::lowVoltageStateOfCharge() const {
+  return m_lowVoltageStateOfCharge;
+}
+
+void HomeController::setLowVoltageStateOfCharge(int charge) {
+  if (charge != m_lowVoltageStateOfCharge) {
+    m_lowVoltageStateOfCharge = charge;
+    emit lowVoltageStateOfChargeChanged(charge);
   }
 }
 

--- a/NERODevelopment/src/controllers/homecontroller.h
+++ b/NERODevelopment/src/controllers/homecontroller.h
@@ -19,8 +19,11 @@ class HomeController : public ButtonController {
                  packTempChanged FINAL)
   Q_PROPERTY(float motorTemp READ motorTemp WRITE setMotorTemp NOTIFY
                  motorTempChanged FINAL)
-  Q_PROPERTY(float stateOfCharge READ stateOfCharge WRITE setStateOfCharge
-                 NOTIFY stateOfChargeChanged FINAL)
+  Q_PROPERTY(int stateOfCharge READ stateOfCharge WRITE setStateOfCharge NOTIFY
+                 stateOfChargeChanged FINAL)
+  Q_PROPERTY(int lowVoltageStateOfCharge READ lowVoltageStateOfCharge WRITE
+                 setLowVoltageStateOfCharge NOTIFY
+                     lowVoltageStateOfChargeChanged FINAL)
 
 public:
   explicit HomeController(Model *model, QObject *parent = nullptr);
@@ -29,7 +32,8 @@ public:
   bool direction() const;
   float packTemp() const;
   float motorTemp() const;
-  float stateOfCharge() const;
+  int stateOfCharge() const;
+  int lowVoltageStateOfCharge() const;
 
 signals:
   void speedChanged(int);
@@ -37,7 +41,8 @@ signals:
   void directionChanged(bool);
   void packTempChanged(float);
   void motorTempChanged(float);
-  void stateOfChargeChanged(float);
+  void stateOfChargeChanged(int);
+  void lowVoltageStateOfChargeChanged(int);
 
 public slots:
   void setSpeed(int);
@@ -45,8 +50,9 @@ public slots:
   void setDirection(bool);
   void setPackTemp(float);
   void setMotorTemp(float);
-  void setStateOfCharge(float);
   void currentDataDidChange();
+  void setStateOfCharge(int);
+  void setLowVoltageStateOfCharge(int);
 
 private:
   int m_speed;
@@ -54,7 +60,8 @@ private:
   bool m_direction;
   float m_packTemp;
   float m_motorTemp;
-  float m_stateOfCharge;
+  int m_stateOfCharge;
+  int m_lowVoltageStateOfCharge;
 };
 
 #endif // HOMECONTROLLER_H


### PR DESCRIPTION
## Changes

Redesigned the pit screen to match the mock
- Increased the size of the degree and percent signs
- Changed color of direction view to match mock
- added hvsoc, lvsoc to pit controller

## Notes

the radial is a different color than what the mock has but not sure if that matters 

## Screenshots

<img width="791" alt="Screenshot 2025-02-17 at 23 28 40" src="https://github.com/user-attachments/assets/da186e95-de98-4a51-81c2-3dbf824c8a5a" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #138
