### PR TITLE
Fixed Mosquitto Incompatibility

### DIFF
--- a/dev-config/mosquitto.conf
+++ b/dev-config/mosquitto.conf
@@ -3,8 +3,6 @@
 # Note that comments cannot be on the same line as uncommented keys (ie # only respected at line position 0)
 # # *** ^^^
 
-max_topic_alias 65534
-
 #per_listener_settings false
 
 allow_zero_length_clientid false
@@ -50,6 +48,8 @@ queue_qos0_messages false
 # =================================================================
 
 listener 1883
+
+max_topic_alias 65534
 
 socket_domain ipv4
 


### PR DESCRIPTION
## Changes

Fixes nero-siren-dev failing to start with eclipse-mosquitto:latest. Moved max_topic_alias from the global scope to after the listener in mosquitto.conf.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #185 
