### PR TITLE
Fixed snake bug

### DIFF
--- a/NERODevelopment/content/Snake.qml
+++ b/NERODevelopment/content/Snake.qml
@@ -30,7 +30,7 @@ Rectangle {
     property bool gameOver: snakeController.gameOver
     property int score: 0
 
-    Component.onCompleted: startGame()
+    Component.onCompleted: snakeController.resetGame()
 
     onDidStartChanged: {
         console.log(direction)
@@ -212,11 +212,4 @@ Rectangle {
         anchors.topMargin: 10
     }
 
-    Connections {
-        target: snakeController
-        onDirectionChanged: {
-            direction = newDirection
-            console.log("Direction updated to:", direction)
-        }
-    }
 }

--- a/NERODevelopment/src/controllers/snakecontroller.cpp
+++ b/NERODevelopment/src/controllers/snakecontroller.cpp
@@ -48,6 +48,15 @@ bool SnakeController::isSameOrOppositeDirection(int newDirection) {
   return (m_direction + 2) % 4 == newDirection || m_direction == newDirection;
 }
 
+void SnakeController::resetGame() {
+  m_gameOver = true;
+  m_direction = 1;
+  m_didStart = false;
+  emit gameOverChanged();
+  emit directionChanged();
+  emit didStartChanged();
+}
+
 void SnakeController::saveScore(int score) {
   QString topic = "SNAKE/SCORE";
   this->m_model->sendMessage(topic, score);

--- a/NERODevelopment/src/controllers/snakecontroller.h
+++ b/NERODevelopment/src/controllers/snakecontroller.h
@@ -29,6 +29,7 @@ public slots:
   void setDidStart(bool);
   void setDirection(int);
   void setGameOver(bool);
+  Q_INVOKABLE void resetGame();
 
 signals:
   void didStartChanged();


### PR DESCRIPTION
## Changes

Added a resetGame method to SnakeController that force resets all game state and is called from Component.onCompleted. This ensures the controller is always in a clean new state when navigating to Snake. I also removed a redundant connections block which was breaking the QML direction property binding on every direction change.

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #198 
