### PR TITLE
165 feature  create reusable screen title component for mode identification

### DIFF
--- a/NERODevelopment/content/EfficiencyScreen.qml
+++ b/NERODevelopment/content/EfficiencyScreen.qml
@@ -35,138 +35,142 @@ Item {
                         }
                     }
 
-    HeaderView {
-        id: header
-    }
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
 
-    RowLayout {
-        id: mainRow
-        anchors {
-            top: header.bottom
-            bottom: parent.bottom
-            right: parent.right
-            left: parent.left
-            rightMargin: efficiency.xMargin
-            leftMargin: efficiency.xMargin
-            bottomMargin: efficiency.yMargin
-        }
-        spacing: 20
-
-        ColumnLayout {
-            id: thermColumn
+        HeaderView {
+            id: header
             Layout.fillWidth: true
-            Layout.fillHeight: true
-            spacing: efficiency.verticalSpacing
-            Layout.preferredWidth: 2
-
-            ThermometerValueComponent {
-                id: motorTempThermometer
-                thermometerValue: efficiency.motorTemp
-                title: "MOTOR TEMP"
-                Layout.fillHeight: true
-                Layout.fillWidth: true
-                radius: efficiency.borderRadii
-                valueFontSize: efficiency.valueFontSize
-                labelFontSize: efficiency.labelFontSize
-            }
-
-            ThermometerValueComponent {
-                id: packTempThermometer
-                thermometerValue: efficiency.packTemp
-                title: "PACK TEMP"
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                radius: efficiency.borderRadii
-                valueFontSize: efficiency.valueFontSize
-                labelFontSize: efficiency.labelFontSize
-            }
-
-            ThermometerValueComponent {
-                id: regen
-                regen: true
-                thermometerValue: efficiency.numRegen
-                title: "REGEN"
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                radius: efficiency.borderRadii
-                valueFontSize: efficiency.valueFontSize
-                labelFontSize: efficiency.labelFontSize
-                unitFontSize: efficiency.labelFontSize / 2
-            }
+            modeTitle: "ENDURANCE"
         }
 
-        ColumnLayout {
-            id: driveColumn
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-            Layout.preferredWidth: 3
-
-            spacing: efficiency.verticalSpacing
-
-            TimerDisplay {
-                id: timerDisplay
-                currentRunTime: efficiency.timerValue
-                lastRunTime: efficiency.lastRunTime
-                fastestRunTime: efficiency.fastestRunTime
-                vertical: true
-                radius: efficiency.borderRadii
-
-                Layout.preferredHeight: 1
-                Layout.fillHeight: true
-                Layout.fillWidth: true
-            }
-
-            Radial {
-                id: spedometer
-                value: efficiency.speed
-                valueFontSize: efficiency.valueFontSize
-
-                Layout.fillHeight: true
-                Layout.fillWidth: true
-                Layout.preferredHeight: 2
-            }
-        }
-
-        ColumnLayout {
-            id: percentColumn
+        RowLayout {
+            id: mainRow
             Layout.fillWidth: true
             Layout.fillHeight: true
-            spacing: efficiency.verticalSpacing
-            Layout.preferredWidth: 2
+            Layout.leftMargin: efficiency.xMargin
+            Layout.rightMargin: efficiency.xMargin
+            Layout.bottomMargin: efficiency.yMargin
 
-            BatteryValueComponent {
-                id: battery
-                title: "HV SOC"
-                batteryValue: efficiency.hvSOC
-                Layout.fillHeight: true
+            spacing: 20
+
+            ColumnLayout {
+                id: thermColumn
                 Layout.fillWidth: true
-                radius: efficiency.borderRadii
-                valueFontSize: efficiency.valueFontSize
-                labelFontSize: efficiency.labelFontSize
-                unitFontSize: efficiency.valueFontSize / 1.5
+                Layout.fillHeight: true
+                spacing: efficiency.verticalSpacing
+                Layout.preferredWidth: 2
+
+                ThermometerValueComponent {
+                    id: motorTempThermometer
+                    thermometerValue: efficiency.motorTemp
+                    title: "MOTOR TEMP"
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    radius: efficiency.borderRadii
+                    valueFontSize: efficiency.valueFontSize
+                    labelFontSize: efficiency.labelFontSize
+                }
+
+                ThermometerValueComponent {
+                    id: packTempThermometer
+                    thermometerValue: efficiency.packTemp
+                    title: "PACK TEMP"
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    radius: efficiency.borderRadii
+                    valueFontSize: efficiency.valueFontSize
+                    labelFontSize: efficiency.labelFontSize
+                }
+
+                ThermometerValueComponent {
+                    id: regen
+                    regen: true
+                    thermometerValue: efficiency.numRegen
+                    title: "REGEN"
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    radius: efficiency.borderRadii
+                    valueFontSize: efficiency.valueFontSize
+                    labelFontSize: efficiency.labelFontSize
+                    unitFontSize: efficiency.labelFontSize / 2
+                }
             }
 
-            BatteryValueComponent {
-                id: battery2
-                title: "LV SOC"
-                batteryValue: efficiency.lvSOC
-                Layout.fillWidth: true
+            ColumnLayout {
+                id: driveColumn
                 Layout.fillHeight: true
-                radius: efficiency.borderRadii
-                valueFontSize: efficiency.valueFontSize
-                labelFontSize: efficiency.labelFontSize
-                unitFontSize: efficiency.valueFontSize / 1.5
+                Layout.fillWidth: true
+                Layout.preferredWidth: 3
+
+                spacing: efficiency.verticalSpacing
+
+                TimerDisplay {
+                    id: timerDisplay
+                    currentRunTime: efficiency.timerValue
+                    lastRunTime: efficiency.lastRunTime
+                    fastestRunTime: efficiency.fastestRunTime
+                    vertical: true
+                    radius: efficiency.borderRadii
+
+                    Layout.preferredHeight: 1
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                }
+
+                Radial {
+                    id: spedometer
+                    value: efficiency.speed
+                    valueFontSize: efficiency.valueFontSize
+
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 2
+                }
             }
 
-            TorqueValueComponent {
-                id: torqueValue
-                torqueValue: efficiency.torqueLimit
-                valueFontSize: efficiency.valueFontSize
-                labelFontSize: efficiency.labelFontSize
-                radius: efficiency.borderRadii
-
+            ColumnLayout {
+                id: percentColumn
                 Layout.fillWidth: true
                 Layout.fillHeight: true
+                spacing: efficiency.verticalSpacing
+                Layout.preferredWidth: 2
+
+                BatteryValueComponent {
+                    id: battery
+                    title: "HV SOC"
+                    batteryValue: efficiency.hvSOC
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    radius: efficiency.borderRadii
+                    valueFontSize: efficiency.valueFontSize
+                    labelFontSize: efficiency.labelFontSize
+                    unitFontSize: efficiency.valueFontSize / 1.5
+                }
+
+                BatteryValueComponent {
+                    id: battery2
+                    title: "LV SOC"
+                    batteryValue: efficiency.lvSOC
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    radius: efficiency.borderRadii
+                    valueFontSize: efficiency.valueFontSize
+                    labelFontSize: efficiency.labelFontSize
+                    unitFontSize: efficiency.valueFontSize / 1.5
+                }
+
+                TorqueValueComponent {
+                    id: torqueValue
+                    torqueValue: efficiency.torqueLimit
+                    valueFontSize: efficiency.valueFontSize
+                    labelFontSize: efficiency.labelFontSize
+                    radius: efficiency.borderRadii
+
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                }
             }
         }
     }

--- a/NERODevelopment/content/HeaderView.qml
+++ b/NERODevelopment/content/HeaderView.qml
@@ -10,8 +10,6 @@ Item {
     property var criticalFaults: headerController.criticalFaults
     property var nonCriticalFaults: headerController.nonCriticalFaults
     property string modeTitle: ""
-    property string statusText: ""
-    property color statusColor: Theme.offCarForeground
 
     Timer {
         id: timer
@@ -65,17 +63,6 @@ Item {
         anchors.centerIn: parent
         color: Theme.offCarForeground
         font.pixelSize: 36
-        font.bold: true
-    }
-
-    LabelText {
-        visible: statusText !== ""
-        text: statusText
-        anchors.right: parent.right
-        anchors.rightMargin: 20
-        anchors.verticalCenter: parent.verticalCenter
-        color: statusColor
-        font.pixelSize: 18
         font.bold: true
     }
 

--- a/NERODevelopment/content/HeaderView.qml
+++ b/NERODevelopment/content/HeaderView.qml
@@ -9,6 +9,9 @@ Item {
 
     property var criticalFaults: headerController.criticalFaults
     property var nonCriticalFaults: headerController.nonCriticalFaults
+    property string modeTitle: ""
+    property string statusText: ""
+    property color statusColor: Theme.offCarForeground
 
     Timer {
         id: timer
@@ -27,6 +30,7 @@ Item {
             delay(3000, faultDialog.closeModal)
         }
     }
+
     onNonCriticalFaultsChanged: {
         if (nonCriticalFaults.length > 0) {
             faultDialog.openModal("Non Critical Faults",
@@ -53,6 +57,26 @@ Item {
         anchors.topMargin: criticalFaultIcon.height / 5
         dimension: parent.height / 2 * 0.9
         numWarnings: criticalFaults.length
+    }
+
+    LabelText {
+        visible: modeTitle !== ""
+        text: modeTitle
+        anchors.centerIn: parent
+        color: Theme.offCarForeground
+        font.pixelSize: 36
+        font.bold: true
+    }
+
+    LabelText {
+        visible: statusText !== ""
+        text: statusText
+        anchors.right: parent.right
+        anchors.rightMargin: 20
+        anchors.verticalCenter: parent.verticalCenter
+        color: statusColor
+        font.pixelSize: 18
+        font.bold: true
     }
 
     FaultDialog {

--- a/NERODevelopment/content/Pit.qml
+++ b/NERODevelopment/content/Pit.qml
@@ -21,114 +21,122 @@ Rectangle {
     property int valueFontSize: Math.min(height / 7.5, width / 7.5)
     property int labelFontSize: Math.min(height / 20, width / 20)
     property int unitFontSize: valueFontSize / 1.5
+    property int titleFontSize: Math.min(height * 0.09, width * 0.06)
 
     color: Theme.background
     height: 480
     width: 800
 
-    HeaderView {
-        id: headerView
-        anchors.top: parent.top
-        anchors.left: parent.left
-        anchors.right: parent.right
-        height: 100
-    }
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
 
-    RowLayout {
-        id: mainRow
-        anchors {
-            leftMargin: pit.horizontalMargin
-            rightMargin: pit.horizontalMargin
-            topMargin: 0
-            bottomMargin: pit.bottomMargin
-            top: headerView.bottom
-            left: parent.left
-            right: parent.right
-            bottom: parent.bottom
-        }
-        spacing: parent.width / 40
-
-        ColumnLayout {
+        HeaderView {
             Layout.fillWidth: true
-            Layout.fillHeight: true
-            Layout.preferredWidth: 5
-            spacing: parent.height / 20
-
-            ThermometerValueComponent {
-                thermometerValue: pit.motorTempValue
-                title: 'MOTOR TEMP'
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                radius: pit.componentRadii
-                valueFontSize: pit.valueFontSize
-                labelFontSize: pit.labelFontSize
-            }
-
-            ThermometerValueComponent {
-                thermometerValue: pit.packTempValue
-                title: 'PACK TEMP'
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                radius: pit.componentRadii
-                valueFontSize: pit.valueFontSize
-                labelFontSize: pit.labelFontSize
-            }
+            height: 100
         }
 
-        ColumnLayout {
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            Layout.preferredWidth: 6
-            spacing: parent.height / 20
-
-            Radial {
-                value: pit.currentSpeed
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                Layout.preferredHeight: 3
-                valueFontSize: pit.valueFontSize
-                maxValue: pit.maxSpeed
-            }
-
-            DirectionView {
-                forward: pit.forward
-                radius: 10
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                Layout.preferredHeight: 1
-                Layout.leftMargin: 20
-                Layout.rightMargin: 20
-            }
+        LabelText {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.topMargin: -70
+            text: pit.forward ? "PIT - DRIVE" : "PIT - REVERSE"
+            color: Theme.offCarForeground
+            font.pixelSize: pit.titleFontSize
+            font.bold: true
         }
 
-        ColumnLayout {
+        RowLayout {
+            id: mainRow
             Layout.fillWidth: true
             Layout.fillHeight: true
-            Layout.preferredWidth: 5
-            spacing: parent.height / 20
+            Layout.leftMargin: pit.horizontalMargin
+            Layout.rightMargin: pit.horizontalMargin
+            Layout.bottomMargin: pit.bottomMargin
 
-            BatteryValueComponent {
+            spacing: pit.width / 40
+
+            ColumnLayout {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
+                Layout.preferredWidth: 5
+                spacing: parent.height / 20
 
-                batteryValue: pit.stateOfChargePercentage
-                title: "HV SOC"
-                radius: pit.componentRadii
-                valueFontSize: pit.valueFontSize
-                labelFontSize: pit.labelFontSize
-                unitFontSize: pit.unitFontSize
+                ThermometerValueComponent {
+                    thermometerValue: pit.motorTempValue
+                    title: 'MOTOR TEMP'
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    radius: pit.componentRadii
+                    valueFontSize: pit.valueFontSize
+                    labelFontSize: pit.labelFontSize
+                }
+
+                ThermometerValueComponent {
+                    thermometerValue: pit.packTempValue
+                    title: 'PACK TEMP'
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    radius: pit.componentRadii
+                    valueFontSize: pit.valueFontSize
+                    labelFontSize: pit.labelFontSize
+                }
             }
 
-            BatteryValueComponent {
+            ColumnLayout {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
+                Layout.preferredWidth: 6
+                spacing: parent.height / 20
 
-                batteryValue: pit.lvStateOfChargePercentage
-                title: "LV SOC"
-                radius: pit.componentRadii
-                valueFontSize: pit.valueFontSize
-                labelFontSize: pit.labelFontSize
-                unitFontSize: pit.unitFontSize
+                Radial {
+                    value: pit.currentSpeed
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    Layout.preferredHeight: 3
+                    valueFontSize: pit.valueFontSize
+                    maxValue: pit.maxSpeed
+                }
+
+                DirectionView {
+                    forward: pit.forward
+                    radius: 10
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    Layout.preferredHeight: 1
+                    Layout.leftMargin: 20
+                    Layout.rightMargin: 20
+                }
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.preferredWidth: 5
+                spacing: parent.height / 20
+
+                BatteryValueComponent {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+
+                    batteryValue: pit.stateOfChargePercentage
+                    title: "HV SOC"
+                    radius: pit.componentRadii
+                    valueFontSize: pit.valueFontSize
+                    labelFontSize: pit.labelFontSize
+                    unitFontSize: pit.unitFontSize
+                }
+
+                BatteryValueComponent {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+
+                    batteryValue: pit.lvStateOfChargePercentage
+                    title: "LV SOC"
+                    radius: pit.componentRadii
+                    valueFontSize: pit.valueFontSize
+                    labelFontSize: pit.labelFontSize
+                    unitFontSize: pit.unitFontSize
+                }
             }
         }
     }

--- a/NERODevelopment/content/Pit.qml
+++ b/NERODevelopment/content/Pit.qml
@@ -21,7 +21,6 @@ Rectangle {
     property int valueFontSize: Math.min(height / 7.5, width / 7.5)
     property int labelFontSize: Math.min(height / 20, width / 20)
     property int unitFontSize: valueFontSize / 1.5
-    property int titleFontSize: Math.min(height * 0.09, width * 0.06)
 
     color: Theme.background
     height: 480
@@ -34,15 +33,7 @@ Rectangle {
         HeaderView {
             Layout.fillWidth: true
             height: 100
-        }
-
-        LabelText {
-            Layout.alignment: Qt.AlignHCenter
-            Layout.topMargin: -70
-            text: pit.forward ? "PIT - DRIVE" : "PIT - REVERSE"
-            color: Theme.offCarForeground
-            font.pixelSize: pit.titleFontSize
-            font.bold: true
+            modeTitle: pit.forward ? "PIT - DRIVE" : "PIT - REVERSE"
         }
 
         RowLayout {

--- a/NERODevelopment/content/SpeedMode.qml
+++ b/NERODevelopment/content/SpeedMode.qml
@@ -35,159 +35,137 @@ Item {
                         }
                     }
 
-    LabelText {
-        id: screenTitle
-        anchors {
-            top: parent.top
-            topMargin: 30
-            horizontalCenter: parent.horizontalCenter
-        }
-        text: "PERFORMANCE"
-        color: Theme.offCarForeground
-        font.pixelSize: 36
-        font.bold: true
-    }
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
 
-    LabelText {
-        id: tractionControl
-        anchors {
-            top: parent.top
-            topMargin: 10
-            right: parent.right
-            rightMargin: speedMode.xMargin
-        }
-        text: speedMode.tractionControlStatus ? "TRACTION CONTROL - ON" : "TRACTION CONTROL - OFF"
-        color: speedMode.tractionControlStatus ? Theme.goodStatus : Theme.criticalStatus
-        font.pixelSize: 18
-        font.bold: true
-    }
-
-    TimerDisplay {
-        id: timerDisplay
-        anchors {
-            top: screenTitle.bottom
-            left: parent.left
-            right: parent.right
-            rightMargin: speedMode.xMargin
-            leftMargin: speedMode.xMargin
-            topMargin: speedMode.verticalSpacing
-        }
-        height: parent.height / 12
-        currentRunTime: speedMode.timerValue
-        lastRunTime: speedMode.lastRunTime
-        fastestRunTime: speedMode.fastestRunTime
-        radius: speedMode.borderRadii
-    }
-
-    RowLayout {
-        id: mainRow
-        anchors {
-            top: timerDisplay.bottom
-            left: parent.left
-            right: parent.right
-            rightMargin: speedMode.xMargin
-            leftMargin: speedMode.xMargin
-            bottom: parent.bottom
-            bottomMargin: speedMode.yMargin
-            topMargin: speedMode.verticalSpacing
-        }
-        spacing: parent.width / 20
-
-        ColumnLayout {
-            Layout.fillHeight: true
+        HeaderView {
+            id: header
             Layout.fillWidth: true
-            Layout.preferredWidth: 1
-            spacing: parent.height / 20
-
-            ThermometerValueComponent {
-                thermometerValue: speedMode.regen
-                title: "Regen"
-                Layout.fillHeight: true
-                Layout.fillWidth: true
-                Layout.preferredHeight: 1
-                radius: speedMode.borderRadii
-                valueFontSize: speedMode.valueFontSize
-                labelFontSize: speedMode.labelFontSize
-                regen: true
-            }
-
-            ThermometerValueComponent {
-                thermometerValue: speedMode.motorTemp
-                title: "MOTOR TEMP"
-                Layout.fillHeight: true
-                Layout.fillWidth: true
-                Layout.preferredHeight: 1
-                radius: speedMode.borderRadii
-                valueFontSize: speedMode.valueFontSize
-                labelFontSize: speedMode.labelFontSize
-            }
-
-            ThermometerValueComponent {
-                thermometerValue: speedMode.packTemp
-                title: "PACK TEMP"
-                Layout.fillHeight: true
-                Layout.fillWidth: true
-                Layout.preferredHeight: 1
-                radius: speedMode.borderRadii
-                valueFontSize: speedMode.valueFontSize
-                labelFontSize: speedMode.labelFontSize
-            }
+            modeTitle: "PERFORMANCE"
+            statusText: speedMode.tractionControlStatus ? "TRACTION CONTROL - ON" : "TRACTION CONTROL - OFF"
+            statusColor: speedMode.tractionControlStatus ? Theme.goodStatus : Theme.criticalStatus
         }
 
-        ColumnLayout {
-            Layout.fillHeight: true
+        TimerDisplay {
+            id: timerDisplay
             Layout.fillWidth: true
-            Layout.preferredWidth: 1
-
-            LabelText {
-                color: Theme.accentForeground
-                text: "TOP SPEED"
-                Layout.preferredHeight: 2
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                font.pixelSize: speedMode.labelFontSize
-            }
-
-            Radial {
-                value: speedMode.maxSpeed
-                Layout.preferredHeight: 9
-                Layout.fillHeight: true
-                Layout.fillWidth: true
-                color: Theme.accentBlue
-                valueFontSize: speedMode.valueFontSize
-                unitFontSize: speedMode.radialUnitFontSize
-            }
+            Layout.leftMargin: speedMode.xMargin
+            Layout.rightMargin: speedMode.xMargin
+            Layout.topMargin: speedMode.verticalSpacing
+            height: speedMode.height / 12
+            currentRunTime: speedMode.timerValue
+            lastRunTime: speedMode.lastRunTime
+            fastestRunTime: speedMode.fastestRunTime
+            radius: speedMode.borderRadii
         }
 
-        ColumnLayout {
-            Layout.fillHeight: true
+        RowLayout {
+            id: mainRow
             Layout.fillWidth: true
-            Layout.preferredWidth: 1
-            clip: false
+            Layout.fillHeight: true
+            Layout.leftMargin: speedMode.xMargin
+            Layout.rightMargin: speedMode.xMargin
+            Layout.bottomMargin: speedMode.yMargin
+            Layout.topMargin: speedMode.verticalSpacing
+            spacing: speedMode.width / 20
 
-            LabelText {
-                color: Theme.accentForeground
-                text: "MAX DRAW"
-                Layout.preferredHeight: 2
-                Layout.fillWidth: true
+            ColumnLayout {
                 Layout.fillHeight: true
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                font.pixelSize: speedMode.labelFontSize
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1
+                spacing: speedMode.height / 20
+
+                ThermometerValueComponent {
+                    thermometerValue: speedMode.regen
+                    title: "Regen"
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 1
+                    radius: speedMode.borderRadii
+                    valueFontSize: speedMode.valueFontSize
+                    labelFontSize: speedMode.labelFontSize
+                    regen: true
+                }
+
+                ThermometerValueComponent {
+                    thermometerValue: speedMode.motorTemp
+                    title: "MOTOR TEMP"
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 1
+                    radius: speedMode.borderRadii
+                    valueFontSize: speedMode.valueFontSize
+                    labelFontSize: speedMode.labelFontSize
+                }
+
+                ThermometerValueComponent {
+                    thermometerValue: speedMode.packTemp
+                    title: "PACK TEMP"
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 1
+                    radius: speedMode.borderRadii
+                    valueFontSize: speedMode.valueFontSize
+                    labelFontSize: speedMode.labelFontSize
+                }
             }
 
-            Radial {
-                value: speedMode.maxDraw
-                Layout.preferredHeight: 9
+            ColumnLayout {
                 Layout.fillHeight: true
                 Layout.fillWidth: true
-                maxValue: 400
-                label: "DCL: " + speedMode.dcl
-                unitLabel: 'A'
-                valueFontSize: speedMode.valueFontSize
-                unitFontSize: speedMode.radialUnitFontSize
+                Layout.preferredWidth: 1
+
+                LabelText {
+                    color: Theme.accentForeground
+                    text: "TOP SPEED"
+                    Layout.preferredHeight: 2
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: speedMode.labelFontSize
+                }
+
+                Radial {
+                    value: speedMode.maxSpeed
+                    Layout.preferredHeight: 9
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    color: Theme.accentBlue
+                    valueFontSize: speedMode.valueFontSize
+                    unitFontSize: speedMode.radialUnitFontSize
+                }
+            }
+
+            ColumnLayout {
+                Layout.fillHeight: true
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1
+                clip: false
+
+                LabelText {
+                    color: Theme.accentForeground
+                    text: "MAX DRAW"
+                    Layout.preferredHeight: 2
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: speedMode.labelFontSize
+                }
+
+                Radial {
+                    value: speedMode.maxDraw
+                    Layout.preferredHeight: 9
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    maxValue: 400
+                    label: "DCL: " + speedMode.dcl
+                    unitLabel: 'A'
+                    valueFontSize: speedMode.valueFontSize
+                    unitFontSize: speedMode.radialUnitFontSize
+                }
             }
         }
     }

--- a/NERODevelopment/content/SpeedMode.qml
+++ b/NERODevelopment/content/SpeedMode.qml
@@ -36,25 +36,36 @@ Item {
                     }
 
     LabelText {
+        id: screenTitle
+        anchors {
+            top: parent.top
+            topMargin: 30
+            horizontalCenter: parent.horizontalCenter
+        }
+        text: "PERFORMANCE"
+        color: Theme.offCarForeground
+        font.pixelSize: 36
+        font.bold: true
+    }
+
+    LabelText {
         id: tractionControl
         anchors {
-            top: speedMode.top
-            topMargin: 20
-            horizontalCenter: speedMode.horizontalCenter
+            top: parent.top
+            topMargin: 10
+            right: parent.right
+            rightMargin: speedMode.xMargin
         }
-        width: speedMode.width * 0.7
-        height: speedMode.height * 0.12
         text: speedMode.tractionControlStatus ? "TRACTION CONTROL - ON" : "TRACTION CONTROL - OFF"
         color: speedMode.tractionControlStatus ? Theme.goodStatus : Theme.criticalStatus
-        font.pixelSize: Math.min(speedMode.height * 0.09,
-                                 speedMode.width * 0.06)
+        font.pixelSize: 18
         font.bold: true
     }
 
     TimerDisplay {
         id: timerDisplay
         anchors {
-            top: tractionControl.bottom
+            top: screenTitle.bottom
             left: parent.left
             right: parent.right
             rightMargin: speedMode.xMargin

--- a/NERODevelopment/content/SpeedMode.qml
+++ b/NERODevelopment/content/SpeedMode.qml
@@ -43,8 +43,15 @@ Item {
             id: header
             Layout.fillWidth: true
             modeTitle: "PERFORMANCE"
-            statusText: speedMode.tractionControlStatus ? "TRACTION CONTROL - ON" : "TRACTION CONTROL - OFF"
-            statusColor: speedMode.tractionControlStatus ? Theme.goodStatus : Theme.criticalStatus
+        }
+
+        LabelText {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.topMargin: -30
+            text: speedMode.tractionControlStatus ? "TRACTION CONTROL - ON" : "TRACTION CONTROL - OFF"
+            color: speedMode.tractionControlStatus ? Theme.goodStatus : Theme.criticalStatus
+            font.pixelSize: 18
+            font.bold: true
         }
 
         TimerDisplay {


### PR DESCRIPTION
## Changes

Added modeTitle property to HeaderView so screens can display their mode name centered in the header. Updated EfficiencyScreen, Pit, and SpeedMode to use it.

## Screenshots

<img width="798" height="478" alt="Screenshot 2026-03-22 at 1 22 35 PM" src="https://github.com/user-attachments/assets/9e91046e-e6f7-4e5f-8095-b2a1ae78599e" />
<img width="797" height="479" alt="Screenshot 2026-03-22 at 1 22 44 PM" src="https://github.com/user-attachments/assets/240a75b6-3ae5-4efd-9a79-0303d948e260" />
<img width="801" height="478" alt="Screenshot 2026-03-22 at 1 22 52 PM" src="https://github.com/user-attachments/assets/de77a448-3223-4041-ac73-0885e74d2d02" />
<img width="799" height="477" alt="Screenshot 2026-03-22 at 1 23 01 PM" src="https://github.com/user-attachments/assets/d9868592-82ad-437f-894c-f893c817d82b" />
<img width="474" height="290" alt="Screenshot 2026-03-22 at 1 23 27 PM" src="https://github.com/user-attachments/assets/4275c0a6-97aa-42b4-9682-6aa7298ab5a0" />
<img width="479" height="292" alt="Screenshot 2026-03-22 at 1 23 34 PM" src="https://github.com/user-attachments/assets/e07abe27-2ac1-48a3-8a97-8ef6860d9f36" />
<img width="478" height="295" alt="Screenshot 2026-03-22 at 1 23 42 PM" src="https://github.com/user-attachments/assets/9688378a-1ab7-4f49-b42f-72fdc587f639" />
<img width="480" height="295" alt="Screenshot 2026-03-22 at 1 23 50 PM" src="https://github.com/user-attachments/assets/fe300322-c550-4f3a-aaa7-6f0dd9e2f9b0" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [X] All commits are tagged with the ticket number
- [X] No linting errors / newline at end of file warnings
- [X] All code follows repository-configured prettier formatting
- [x]   No merge conflicts
- [X] All checks passing
- [X] Screenshots of UI changes (see Screenshots section)
- [X] Remove any non-applicable sections of this template
- [X] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack
- [X] PR is linked to the ticket (fill in the closes line below)

Closes #165