### PR TITLE
Updated data_type_names.h for VCU Topics

### DIFF
--- a/NERODevelopment/src/models/model.h
+++ b/NERODevelopment/src/models/model.h
@@ -54,7 +54,7 @@ public:
   virtual std::optional<float> getRegenPower() = 0;
   virtual std::optional<float> getBmsState() = 0;
   virtual QList<QString> getBmsFault() = 0;
-  virtual QList<QString> getMpuFault() = 0;
+  virtual QList<QString> getVcuFault() = 0;
   virtual std::optional<float> getDcl() = 0;
   virtual std::optional<float> getCcl() = 0;
   virtual std::optional<float> getPackCurrent() = 0;

--- a/NERODevelopment/src/models/raspberry_model.cpp
+++ b/NERODevelopment/src/models/raspberry_model.cpp
@@ -18,8 +18,8 @@ RaspberryModel::RaspberryModel() {}
 
 RaspberryModel::~RaspberryModel() {}
 
-QList<QString> RaspberryModel::getMpuFault() {
-  QRegularExpression regex("^MPU/Fault/.*$");
+QList<QString> RaspberryModel::getVcuFault() {
+  QRegularExpression regex("^VCU/Faults/.*$");
 
   QList<QString> faults;
   for (auto it = this->currentData.begin(); it != this->currentData.end();
@@ -66,7 +66,7 @@ void RaspberryModel::connectToMQTT() {
       INVERTERTEMP,
       BMSSTATE,
       BMSFAULT,
-      MPUFAULT,
+      VCUFAULT,
       DCL,
       CCL,
       REGENPOWER,

--- a/NERODevelopment/src/models/raspberry_model.h
+++ b/NERODevelopment/src/models/raspberry_model.h
@@ -50,7 +50,7 @@ public:
   std::optional<float> getRegenPower() override;
   std::optional<float> getBmsState() override;
   QList<QString> getBmsFault() override;
-  QList<QString> getMpuFault() override;
+  QList<QString> getVcuFault() override;
   std::optional<float> getDcl() override;
   std::optional<float> getCcl() override;
   std::optional<float> getPackCurrent() override;

--- a/NERODevelopment/src/utils/data_type_names.h
+++ b/NERODevelopment/src/utils/data_type_names.h
@@ -25,7 +25,6 @@
 #define INVERTERTEMP "DTI/Temps/Controller_Temperature"
 #define BMSSTATE "BMS/Status/State"
 #define BMSFAULT "BMS/Faults/Critical/#"
-//#define MPUFAULT "MPU/Fault/#" - see VCUFAULT (literally just a name change for the define, everything else should be structured the same)
 #define DCL "BMS/Commands/Max_DC_Current_Target"
 #define CCL "BMS/Commands/Max_DC_Brake_Current_Target"
 #define FORWARDBUTTON "Wheel/Buttons/button_id"

--- a/NERODevelopment/src/utils/data_type_names.h
+++ b/NERODevelopment/src/utils/data_type_names.h
@@ -59,6 +59,8 @@
 #define FANPOWER "VCU/eFuses/Fanbatt/Current" // Current (A) flowing through battbox fan eFuse.
 #define EFUSE_SHUTDOWN_ENABLED "VCU/eFuses/Shutdown/Enabled?" // '1' if the Shutdown eFuse is enabled (i.e., current is allowed to flow through it). '0' if the Shutdown eFuse is disabled (i.e., current can't flow through it).
 #define EFUSE_SHUTDOWN_FAULTED "VCU/eFuses/Shutdown/Faulted?" // '1' if the Shutdown eFuse has been tripped (i.e., it detected overcurrent and is now blocking all current from flowing through it). '0' if the Shutdown eFuse is not faulted.
+#define EFUSE_MC_ENABLED "VCU/eFuses/MC/Enabled?" // '1' if the Motor Controller eFuse is enabled (i.e., current is allowed to flow through it). '0' if the Motor Controller eFuse is disabled (i.e., current can't flow through it).
+#define EFUSE_MC_FAULTED "VCU/eFuses/MC/Faulted?" // '1' if the Motor Controller eFuse has been tripped (i.e., it detected overcurrent and is now blocking all current from flowing through it). '0' if the Motor Controller eFuse is not faulted.
 #define BMS "VCU/Shutdown/BMS_GPIO"
 #define BSPD "VCU/Shutdown/BSPD_GPIO"
 #define BOTS "VCU/Shutdown/BOTS_GPIO"

--- a/NERODevelopment/src/utils/data_type_names.h
+++ b/NERODevelopment/src/utils/data_type_names.h
@@ -21,7 +21,7 @@
 #define MINCELLVOLTAGECELL "BMS/Cells/Volts_Low_Cell"
 #define AVECELLTEMP "BMS/Status/Temp_Average"
 #define AVECELLVOLTAGE "BMS/Cells/Volts_Avg_Value"
-//#define TRACTIONCONTROL "MPU/State/LaunchControl" - see LAUNCHCONTROL and TRACTIONCONTROL
+#define TRACTIONCONTROL "MPU/State/LaunchControl" // OUTDATED-ISH MPU TOPIC - see LAUNCHCONTROL and TRACTIONCONTROL
 #define INVERTERTEMP "DTI/Temps/Controller_Temperature"
 #define BMSSTATE "BMS/Status/State"
 #define BMSFAULT "BMS/Faults/Critical/#"
@@ -37,11 +37,11 @@
 #define SEGMENTTEMP2 "BMS/Segment_Temp/2"
 #define SEGMENTTEMP3 "BMS/Segment_Temp/3"
 #define SEGMENTTEMP4 "BMS/Segment_Temp/4"
-//#define SIDEBRBS "MPU/Fuses/SD_TO_BRB_FUSE_STAT" - see VCU_EFUSE_SHUTDOWN_ENABLED and VCU_EFUSE_SHUTDOWN_FAULTED
-//#define MPU "MPU/Shutdown/MC_STAT" - see VCU_EFUSE_MC_ENABLED and VCU_EFUSE_MC_FAULTED
+#define SIDEBRBS "MPU/Fuses/SD_TO_BRB_FUSE_STAT" // OUTDATED MPU TOPIC - see VCU_EFUSE_SHUTDOWN_ENABLED and VCU_EFUSE_SHUTDOWN_FAULTED
+#define MPU "MPU/Shutdown/MC_STAT" // OUTDATED MPU TOPIC - see VCU_EFUSE_MC_ENABLED and VCU_EFUSE_MC_FAULTED
 #define CRITICALFAULTS "BMS/Faults/Critical/#"
 #define NONCRITICALFAULTS "BMS/Faults/Non-Critical/#"
-//#define LOWVOLTAGESOC "MPU/Sense/SOC" - no equivalent topic exists on VCU as of right now.
+#define LOWVOLTAGESOC "MPU/Sense/SOC" // OUTDATED MPU TOPIC - no equivalent topic exists on VCU as of right now.
 
 /* VCU Topics */
 #define TORQUEPOWER "VCU/CarState/torque_limit_percentage"

--- a/NERODevelopment/src/utils/data_type_names.h
+++ b/NERODevelopment/src/utils/data_type_names.h
@@ -1,9 +1,6 @@
 #ifndef DATATYPENAMES_H
 #define DATATYPENAMES_H
 
-#define MPH "VCU/CarState/speed"
-#define STATUS "MPU/State/TSMS"
-#define DIRECTION "MPU/State/Direction"
 #define PACKTEMP "BMS/Status/Temp_Average"
 #define MOTORTEMP "DTI/Temps/Motor_Temperature"
 #define STATEOFCHARGE "BMS/Pack/SOC"
@@ -24,12 +21,11 @@
 #define MINCELLVOLTAGECELL "BMS/Cells/Volts_Low_Cell"
 #define AVECELLTEMP "BMS/Status/Temp_Average"
 #define AVECELLVOLTAGE "BMS/Cells/Volts_Avg_Value"
-#define TRACTIONCONTROL "MPU/State/LaunchControl"
+//#define TRACTIONCONTROL "MPU/State/LaunchControl" - see LAUNCHCONTROL and TRACTIONCONTROL
 #define INVERTERTEMP "DTI/Temps/Controller_Temperature"
-#define REGENPOWER "VCU/CarState/regen_limit"
 #define BMSSTATE "BMS/Status/State"
 #define BMSFAULT "BMS/Faults/Critical/#"
-#define MPUFAULT "MPU/Fault/#"
+//#define MPUFAULT "MPU/Fault/#" - see VCUFAULT (literally just a name change for the define, everything else should be structured the same)
 #define DCL "BMS/Commands/Max_DC_Current_Target"
 #define CCL "BMS/Commands/Max_DC_Brake_Current_Target"
 #define FORWARDBUTTON "Wheel/Buttons/button_id"
@@ -38,29 +34,41 @@
 #define ENTERBUTTON "Wheel/Buttons/button_id"
 #define UPBUTTON "Wheel/Buttons/button_id"
 #define DOWNBUTTON "Wheel/Buttons/button_id"
-#define HOMEBUTTON "MPU/State/Mode"
-#define MODEINDEX "MPU/State/ModeIndex"
-#define GFORCE "VCU/IMU/Accelerometer"
 #define SEGMENTTEMP1 "BMS/Segment_Temp/1"
 #define SEGMENTTEMP2 "BMS/Segment_Temp/2"
 #define SEGMENTTEMP3 "BMS/Segment_Temp/3"
 #define SEGMENTTEMP4 "BMS/Segment_Temp/4"
-#define TORQUEPOWER "VCU/CarState/torque_limit_percentage"
-#define MOTORPOWER "MPU/Current/Motor_Controller"
-#define FANPOWER "MPU/Current/Battbox_Fans"
-#define SIDEBRBS "MPU/Fuses/SD_TO_BRB_FUSE_STAT"
-#define BMS "MPU/Shutdown/BMS_GOOD"
-#define BSPD "MPU/Shutdown/BSPD_GOOD"
-#define MPU "MPU/Shutdown/MC_STAT"
-#define BOTS "MPU/Shutdown/BOTS_GOOD"
-#define INERTIA "MPU/Shutdown/INERTIA_SW_GOOD"
-#define CPBRB "MPU/GPIO_EXPANDER_DEBUG/SHUTDOWN/CKPT_BRB_CLR"
-#define TSMS "MPU/State/TSMS"
-#define IMD "MPU/Shutdown/IMD_GOOD"
-#define HVDINTRLK "MPU/Shutdown/HVD_INTLK_GOOD"
-#define HVCNCTR "MPU/Shutdown/HVC_INTLK_GOOD"
+//#define SIDEBRBS "MPU/Fuses/SD_TO_BRB_FUSE_STAT" - see VCU_EFUSE_SHUTDOWN_ENABLED and VCU_EFUSE_SHUTDOWN_FAULTED
+//#define MPU "MPU/Shutdown/MC_STAT" - see VCU_EFUSE_MC_ENABLED and VCU_EFUSE_MC_FAULTED
 #define CRITICALFAULTS "BMS/Faults/Critical/#"
 #define NONCRITICALFAULTS "BMS/Faults/Non-Critical/#"
-#define LOWVOLTAGESOC "MPU/Sense/SOC"
+//#define LOWVOLTAGESOC "MPU/Sense/SOC" - no equivalent topic exists on VCU as of right now.
+
+/* VCU Topics */
+#define TORQUEPOWER "VCU/CarState/torque_limit_percentage"
+#define GFORCE "VCU/IMU/Accelerometer"
+#define REGENPOWER "VCU/CarState/regen_limit"
+#define MPH "VCU/CarState/speed"
+#define STATUS "VCU/CarState/tsms" // '1' if TSMS is on, '0' if TSMS is off. Refers to the "Official" TSMS state (not the raw pin state, but the state stored in the debounced 'tsms' bool).
+#define DIRECTION "VCU/CarState/not_in_reverse" // '1' means that `cerberus_state.functional != F_REVERSE`. '0' means that 'cerberus_state.functional == F_REVERSE'.
+#define LAUNCHCONTROL "VCU/CarState/launch_control" // '1' indicates that launch control is enabled. '0' indicates that launch control is disabled.
+#define TRACTIONCONTROL "VCU/CarState/traction_control" // '1' indicates that traction control is enabled. '0' indicates that traction control is disabled.
+#define VCUFAULT "VCU/Faults/#" // '1' indicates that the fault is active, '0' indicates that the fault is inactive.
+#define HOMEBUTTON "VCU/CarState/home_mode" // '1' indicates that VCU is in home mode. '0' indicates that VCU is not in home mode.
+#define MODEINDEX "VCU/CarState/nero_index" // '0' = OFF, '1' = PIT, '2' = REVERSE, '3' = PERFORMANCE, '4' = EFFICIENCY, '5' = GAMES, '6' = EXIT
+#define MOTORPOWER "VCU/eFuses/MC/Current" // Current (A) flowing through motor controller eFuse.
+#define FANPOWER "VCU/eFuses/Fanbatt/Current" // Current (A) flowing through battbox fan eFuse.
+#define EFUSE_SHUTDOWN_ENABLED "VCU/eFuses/Shutdown/Enabled?" // '1' if the Shutdown eFuse is enabled (i.e., current is allowed to flow through it). '0' if the Shutdown eFuse is disabled (i.e., current can't flow through it).
+#define EFUSE_SHUTDOWN_FAULTED "VCU/eFuses/Shutdown/Faulted?" // '1' if the Shutdown eFuse has been tripped (i.e., it detected overcurrent and is now blocking all current from flowing through it). '0' if the Shutdown eFuse is not faulted.
+#define BMS "VCU/Shutdown/BMS_GPIO"
+#define BSPD "VCU/Shutdown/BSPD_GPIO"
+#define BOTS "VCU/Shutdown/BOTS_GPIO"
+#define INERTIA "VCU/Shutdown/INERTIA_SW_GPIO"
+#define CPBRB "VCU/Shutdown/CKPT_GPIO"
+#define TSMS "VCU/CarState/tsms" // seems to be a duplicate of STATUS
+#define IMD "VCU/Shutdown/IMD_GPIO"
+#define HVDINTRLK "VCU/Shutdown/HVD_GPIO"
+#define HVCNCTR "VCU/Shutdown/HV_C_GPIO"
+
 
 #endif // DATATYPENAMES_H


### PR DESCRIPTION
Updated old MPU topic macros in `data_type_names.h` to their equivalent VCU topics.

Most of the existing MPU macros had straightforward VCU equivalents, so I just updated the topic strings without changing the macro names themselves. Some MPU topics don't have straightforward VCU equivalents though, since VCU does a few things a bit differently than MPU. I commented those macros out (rather than fully updating/replacing them), so Nero devs can look over the differences and decide what VCU topics they want to use as a replacement + if they need to make any UI changes to accommodate the VCU differences.

Anyway here's my notes about the topics that couldn't be easily replaced:
`#define TRACTIONCONTROL "MPU/State/LaunchControl"`: 
- VCU has both launch control and traction control toggles, so I'm assuming Nero will want to report both of them on the UI somewhere? 
- I added `#define TRACTIONCONTROL "VCU/CarState/traction_control"` and `#define LAUNCHCONTROL "VCU/CarState/launch_control"` for that reason. 
- So, not really that different from MPU aside from it being two topics instead of one

\
`#define SIDEBRBS "MPU/Fuses/SD_TO_BRB_FUSE_STAT"`: 
- VCU has no direct equivalent to this topic because it doesn't report a single "status" for each of its eFuses. 
- Instead, it reports an "Enabled?" status and a "Faulted?" status for each eFuse. For SIDEBRBS, the relevant topics on VCU are `#define EFUSE_SHUTDOWN_ENABLED "VCU/eFuses/Shutdown/Enabled?"` (whether or not current is allowed to flow through the eFuse) and `#define EFUSE_SHUTDOWN_FAULTED "VCU/eFuses/Shutdown/Faulted?"` (whether or not the eFuse has been tripped). 
- So the VCU equivalent to MPU's SIDEBRBS topic would be doing `EFUSE_SHUTDOWN_ENABLED && !EFUSE_SHUTDOWN_FAULTED`

\
`#define MPU "MPU/Shutdown/MC_STAT"`:
- Same thing as with SIDEBRBS (i.e., VCU eFuses don't report a single status like this). The equivalent two for MC_STAT would be `#define EFUSE_MC_ENABLED "VCU/eFuses/MC/Enabled?"` and `#define EFUSE_MC_FAULTED "VCU/eFuses/MC/Faulted?"`

\
`#define LOWVOLTAGESOC "MPU/Sense/SOC"`:
- There's no equivalent VCU topic for SOC. The closest would be `VCU/LV/voltage`, which reports the voltage reading of the 24V line.

\
TLDR Nero UI etc. might need to be updated a tiny bit to handle these differences

\
Also, I mainly just updated the `data_type_names.h` macros in this PR, so if topics and other MPU-related stuff is hardcoded in other files they might need to be tweaked a bit.

