### PR TITLE
Fix Timer Callback Leak in Faults

### DIFF
--- a/NERODevelopment/content/HeaderView.qml
+++ b/NERODevelopment/content/HeaderView.qml
@@ -12,20 +12,16 @@ Item {
     property string modeTitle: ""
 
     Timer {
-        id: timer
-    }
-
-    function delay(delayTime, cb) {
-        timer.interval = delayTime
-        timer.repeat = false
-        timer.triggered.connect(cb)
-        timer.start()
+        id: autoCloseTimer
+        interval: 3000
+        repeat: false
+        onTriggered: faultDialog.closeModal()
     }
 
     onCriticalFaultsChanged: {
         if (criticalFaults.length > 0) {
             faultDialog.openModal("Critical Faults", criticalFaults.join("\n"))
-            delay(3000, faultDialog.closeModal)
+            autoCloseTimer.restart()
         }
     }
 
@@ -33,7 +29,7 @@ Item {
         if (nonCriticalFaults.length > 0) {
             faultDialog.openModal("Non Critical Faults",
                                   nonCriticalFaults.join("\n"))
-            delay(3000, faultDialog.closeModal)
+            autoCloseTimer.restart()
         }
     }
 


### PR DESCRIPTION
## Changes

Replaced the generic Timer with autoCloseTimer so that the timer call backs don't accumulate. Functionality remains the same.

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #212 
