### PR TITLE
Fixed fault text color

### DIFF
--- a/NERODevelopment/content/FaultDialog.qml
+++ b/NERODevelopment/content/FaultDialog.qml
@@ -29,7 +29,7 @@ Popup {
 
         Text {
             id: modalTitle
-            color: Theme.inverseForeground
+            color: Theme.blackForeground
             font.pixelSize: dimension / 6
             font.bold: true
             wrapMode: Text.WordWrap
@@ -43,7 +43,7 @@ Popup {
 
         Text {
             id: modalDescription
-            color: Theme.inverseForeground
+            color: Theme.blackForeground
             font.pixelSize: dimension / 11
             wrapMode: Text.WordWrap
             anchors.left: parent.left


### PR DESCRIPTION
## Changes

Replace `Theme.inverseForeground` with `Theme.blackForeground` so fault alert text is always black on the white popover background.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #215 
