### PR TITLE
Combine Fault Alerts

### DIFF
--- a/NERODesign/content/Keyboard.qml
+++ b/NERODesign/content/Keyboard.qml
@@ -493,15 +493,17 @@ Item {
             textInput.cursorPosition = position - 1;
         } else if (text === '\u2191')
             shift = !shift;
-            // UPWARDS ARROW (shift)
-        else if (text === '@#')
+        else
+        // UPWARDS ARROW (shift)
+        if (text === '@#')
             symbols = true;
         else if (text === 'AB')
             symbols = false;
         else if (text === '\u21B5')
             accepted(textInput.text);
-            // DOWNWARDS ARROW WITH CORNER LEFTWARDS (enter)
-        else {
+        else
+        // DOWNWARDS ARROW WITH CORNER LEFTWARDS (enter)
+        {
             // insert text
             var position = textInput.cursorPosition;
             textInput.text = textInput.text.substring(0, textInput.cursorPosition) + text + textInput.text.substring(textInput.cursorPosition, textInput.text.length);

--- a/NERODevelopment/content/DoomView.qml
+++ b/NERODevelopment/content/DoomView.qml
@@ -15,23 +15,23 @@ Item {
     // DOOM key codes from doomgeneric's doomkeys.h
     // (https://github.com/ozkl/doomgeneric/blob/master/doomgeneric/doomkeys.h)
     // These must match the values defined in the library — they are NOT arbitrary.
-    readonly property int doomKeyUp:      0xAD  // KEY_UPARROW
-    readonly property int doomKeyDown:    0xAF  // KEY_DOWNARROW
-    readonly property int doomKeyLeft:    0xAC  // KEY_LEFTARROW
-    readonly property int doomKeyRight:   0xAE  // KEY_RIGHTARROW
-    readonly property int doomKeyEnter:   0x0D  // KEY_ENTER
-    readonly property int doomKeyFire:    0x9D  // KEY_FIRE (ctrl)
-    readonly property int doomKeyUse:     0x20  // KEY_USE (space — open doors, switches)
-    readonly property int doomKeyEscape:  0x1B  // KEY_ESCAPE
+    readonly property int doomKeyUp: 0xAD  // KEY_UPARROW
+    readonly property int doomKeyDown: 0xAF  // KEY_DOWNARROW
+    readonly property int doomKeyLeft: 0xAC  // KEY_LEFTARROW
+    readonly property int doomKeyRight: 0xAE  // KEY_RIGHTARROW
+    readonly property int doomKeyEnter: 0x0D  // KEY_ENTER
+    readonly property int doomKeyFire: 0x9D  // KEY_FIRE (ctrl)
+    readonly property int doomKeyUse: 0x20  // KEY_USE (space — open doors, switches)
+    readonly property int doomKeyEscape: 0x1B  // KEY_ESCAPE
 
     onIsFocusedChanged: {
         if (isFocused) {
             if (!doomController.running) {
-                doomController.startGame()
+                doomController.startGame();
             }
         } else {
             if (doomController.running) {
-                doomController.stopGame()
+                doomController.stopGame();
             }
         }
     }
@@ -46,21 +46,19 @@ Item {
         anchors.centerIn: parent
 
         width: {
-            var scaleX = parent.width / 640
-            var scaleY = parent.height / 400
-            var scale = Math.min(scaleX, scaleY)
-            return 640 * scale
+            var scaleX = parent.width / 640;
+            var scaleY = parent.height / 400;
+            var scale = Math.min(scaleX, scaleY);
+            return 640 * scale;
         }
         height: {
-            var scaleX = parent.width / 640
-            var scaleY = parent.height / 400
-            var scale = Math.min(scaleX, scaleY)
-            return 400 * scale
+            var scaleX = parent.width / 640;
+            var scaleY = parent.height / 400;
+            var scale = Math.min(scaleX, scaleY);
+            return 400 * scale;
         }
 
-        source: doomController.running
-                ? "image://doom/frame?" + doomController.frameCounter
-                : ""
+        source: doomController.running ? "image://doom/frame?" + doomController.frameCounter : ""
 
         // nearest-neighbor scaling preserves DOOM's original pixel art look
         smooth: false
@@ -75,72 +73,72 @@ Item {
         visible: doomController.running
     }
 
-    Keys.onPressed: function(event) {
-        if (event.isAutoRepeat) return
-
+    Keys.onPressed: function (event) {
+        if (event.isAutoRepeat)
+            return;
         switch (event.key) {
-            case Qt.Key_Up:
-                doomController.sendKey(doomKeyUp, true)
-                event.accepted = true
-                break
-            case Qt.Key_Down:
-                doomController.sendKey(doomKeyDown, true)
-                event.accepted = true
-                break
-            case Qt.Key_Left:
-                doomController.sendKey(doomKeyLeft, true)
-                event.accepted = true
-                break
-            case Qt.Key_Right:
-                doomController.sendKey(doomKeyRight, true)
-                event.accepted = true
-                break
-            case Qt.Key_Return:
-                if (!doomController.running) {
-                    doomController.startGame()
-                } else {
-                    doomController.sendKey(doomKeyEnter, true)
-                    doomController.sendKey(doomKeyFire, true)
-                    doomController.sendKey(doomKeyUse, true)
-                }
-                event.accepted = true
-                break
-            case Qt.Key_Escape:
-                if (doomController.running) {
-                    doomController.stopGame()
-                }
-                navigationController.goHome()
-                event.accepted = true
-                break
+        case Qt.Key_Up:
+            doomController.sendKey(doomKeyUp, true);
+            event.accepted = true;
+            break;
+        case Qt.Key_Down:
+            doomController.sendKey(doomKeyDown, true);
+            event.accepted = true;
+            break;
+        case Qt.Key_Left:
+            doomController.sendKey(doomKeyLeft, true);
+            event.accepted = true;
+            break;
+        case Qt.Key_Right:
+            doomController.sendKey(doomKeyRight, true);
+            event.accepted = true;
+            break;
+        case Qt.Key_Return:
+            if (!doomController.running) {
+                doomController.startGame();
+            } else {
+                doomController.sendKey(doomKeyEnter, true);
+                doomController.sendKey(doomKeyFire, true);
+                doomController.sendKey(doomKeyUse, true);
+            }
+            event.accepted = true;
+            break;
+        case Qt.Key_Escape:
+            if (doomController.running) {
+                doomController.stopGame();
+            }
+            navigationController.goHome();
+            event.accepted = true;
+            break;
         }
     }
 
-    Keys.onReleased: function(event) {
-        if (event.isAutoRepeat) return
-
+    Keys.onReleased: function (event) {
+        if (event.isAutoRepeat)
+            return;
         switch (event.key) {
-            case Qt.Key_Up:
-                doomController.sendKey(doomKeyUp, false)
-                event.accepted = true
-                break
-            case Qt.Key_Down:
-                doomController.sendKey(doomKeyDown, false)
-                event.accepted = true
-                break
-            case Qt.Key_Left:
-                doomController.sendKey(doomKeyLeft, false)
-                event.accepted = true
-                break
-            case Qt.Key_Right:
-                doomController.sendKey(doomKeyRight, false)
-                event.accepted = true
-                break
-            case Qt.Key_Return:
-                doomController.sendKey(doomKeyEnter, false)
-                doomController.sendKey(doomKeyFire, false)
-                doomController.sendKey(doomKeyUse, false)
-                event.accepted = true
-                break
+        case Qt.Key_Up:
+            doomController.sendKey(doomKeyUp, false);
+            event.accepted = true;
+            break;
+        case Qt.Key_Down:
+            doomController.sendKey(doomKeyDown, false);
+            event.accepted = true;
+            break;
+        case Qt.Key_Left:
+            doomController.sendKey(doomKeyLeft, false);
+            event.accepted = true;
+            break;
+        case Qt.Key_Right:
+            doomController.sendKey(doomKeyRight, false);
+            event.accepted = true;
+            break;
+        case Qt.Key_Return:
+            doomController.sendKey(doomKeyEnter, false);
+            doomController.sendKey(doomKeyFire, false);
+            doomController.sendKey(doomKeyUse, false);
+            event.accepted = true;
+            break;
         }
     }
 
@@ -150,13 +148,13 @@ Item {
     Connections {
         target: doomController
         function onEscapeRequested() {
-            navigationController.goHome()
+            navigationController.goHome();
         }
     }
 
     Component.onDestruction: {
         if (doomController.running) {
-            doomController.stopGame()
+            doomController.stopGame();
         }
     }
 }

--- a/NERODevelopment/content/FaultDialog.qml
+++ b/NERODevelopment/content/FaultDialog.qml
@@ -1,12 +1,14 @@
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import NERO
 
 Popup {
     id: modal
     property int dimension: 500
     property int offset: (modal.width * .02)
+    property var criticalList: []
+    property var nonCriticalList: []
+
     focus: false
     modal: true
     width: dimension * 2
@@ -27,41 +29,43 @@ Popup {
         color: Theme.popoverBackground
         radius: 20
 
-        Text {
-            id: modalTitle
-            color: Theme.blackForeground
-            font.pixelSize: dimension / 6
-            font.bold: true
-            wrapMode: Text.WordWrap
-            width: (parent.width - modalTitle.x) - modal.offset
-            anchors.top: parent.top
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.leftMargin: 5
-            anchors.topMargin: 5
+        Column {
+            anchors.fill: parent
+            anchors.margins: 5
+            spacing: 4
+
+            Text {
+                text: "Faults"
+                color: Theme.blackForeground
+                font.pixelSize: modal.dimension / 6
+                font.bold: true
+                wrapMode: Text.WordWrap
+                width: parent.width
+            }
+
+            Repeater {
+                model: modal.criticalList
+                delegate: Text {
+                    required property string modelData
+                    text: modelData
+                    color: Theme.criticalStatus
+                    font.pixelSize: modal.dimension / 11
+                    wrapMode: Text.WordWrap
+                    width: parent.width
+                }
+            }
+
+            Repeater {
+                model: modal.nonCriticalList
+                delegate: Text {
+                    required property string modelData
+                    text: modelData
+                    color: Theme.accentGreen
+                    font.pixelSize: modal.dimension / 11
+                    wrapMode: Text.WordWrap
+                    width: parent.width
+                }
+            }
         }
-
-        Text {
-            id: modalDescription
-            color: Theme.blackForeground
-            font.pixelSize: dimension / 11
-            wrapMode: Text.WordWrap
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.bottom: parent.bottom
-            anchors.top: modalTitle.bottom
-            anchors.leftMargin: 5
-            anchors.topMargin: 5
-        }
-    }
-
-    function openModal(title, text) {
-        modalTitle.text = title;
-        modalDescription.text = text;
-        modal.open();
-    }
-
-    function closeModal() {
-        modal.close();
     }
 }

--- a/NERODevelopment/content/FaultDialog.qml
+++ b/NERODevelopment/content/FaultDialog.qml
@@ -60,7 +60,7 @@ Popup {
                 delegate: Text {
                     required property string modelData
                     text: modelData
-                    color: Theme.accentGreen
+                    color: Theme.accentBlue
                     font.pixelSize: modal.dimension / 11
                     wrapMode: Text.WordWrap
                     width: parent.width

--- a/NERODevelopment/content/HeaderView.qml
+++ b/NERODevelopment/content/HeaderView.qml
@@ -15,22 +15,21 @@ Item {
         id: autoCloseTimer
         interval: 3000
         repeat: false
-        onTriggered: faultDialog.closeModal()
+        onTriggered: faultDialog.close()
     }
 
-    onCriticalFaultsChanged: {
-        if (criticalFaults.length > 0) {
-            faultDialog.openModal("Critical Faults", criticalFaults.join("\n"));
-            autoCloseTimer.restart();
+    function refreshFaultDialog() {
+        if (criticalFaults.length === 0 && nonCriticalFaults.length === 0) {
+            faultDialog.close();
+            autoCloseTimer.stop();
+            return;
         }
+        faultDialog.open();
+        autoCloseTimer.restart();
     }
 
-    onNonCriticalFaultsChanged: {
-        if (nonCriticalFaults.length > 0) {
-            faultDialog.openModal("Non Critical Faults", nonCriticalFaults.join("\n"));
-            autoCloseTimer.restart();
-        }
-    }
+    onCriticalFaultsChanged: refreshFaultDialog()
+    onNonCriticalFaultsChanged: refreshFaultDialog()
 
     NonCriticalWarning {
         id: nonCriticalWarning
@@ -64,5 +63,7 @@ Item {
     FaultDialog {
         id: faultDialog
         dimension: 300
+        criticalList: criticalFaults
+        nonCriticalList: nonCriticalFaults
     }
 }

--- a/NERODevelopment/src/controllers/doomcontroller.cpp
+++ b/NERODevelopment/src/controllers/doomcontroller.cpp
@@ -28,9 +28,9 @@
 #include "doomcontroller.h"
 
 #include <QCoreApplication>
+#include <QDebug>
 #include <QDir>
 #include <QFile>
-#include <QDebug>
 
 #include "../utils/data_type_names.h"
 
@@ -43,10 +43,10 @@
  * These headers are from the upstream repo and should not be modified.
  * ============================================================ */
 extern "C" {
+#include "d_event.h"
 #include "doomgeneric.h"
 #include "doomkeys.h"
 #include "doomtype.h"
-#include "d_event.h"
 #include "z_zone.h"
 
 extern int joybspeed;
@@ -67,23 +67,22 @@ extern void D_PostEvent(event_t *ev);
  *   Phys 7 (Right)        → MQTT 6
  *   Phys 8 (Middle Right) → MQTT 7
  * ============================================================ */
-static constexpr int BUTTON_VALUE_ESCAPE       = 0;  // physical 1 — escape
-static constexpr int BUTTON_VALUE_LEFT         = 1;  // physical 2 — turn left
-static constexpr int BUTTON_VALUE_MIDDLE_LEFT  = 2;  // physical 3 — also turn left
-static constexpr int BUTTON_VALUE_UP           = 3;  // physical 4 — move forward
-static constexpr int BUTTON_VALUE_DOWN         = 4;  // physical 5 — move backward
-static constexpr int BUTTON_VALUE_ENTER        = 5;  // physical 6 — fire+use+menu
-static constexpr int BUTTON_VALUE_RIGHT        = 6;  // physical 7 — turn right
-static constexpr int BUTTON_VALUE_MIDDLE_RIGHT = 7;  // physical 8 — also turn right
+static constexpr int BUTTON_VALUE_ESCAPE = 0; // physical 1 — escape
+static constexpr int BUTTON_VALUE_LEFT = 1;   // physical 2 — turn left
+static constexpr int BUTTON_VALUE_MIDDLE_LEFT =
+    2;                                       // physical 3 — also turn left
+static constexpr int BUTTON_VALUE_UP = 3;    // physical 4 — move forward
+static constexpr int BUTTON_VALUE_DOWN = 4;  // physical 5 — move backward
+static constexpr int BUTTON_VALUE_ENTER = 5; // physical 6 — fire+use+menu
+static constexpr int BUTTON_VALUE_RIGHT = 6; // physical 7 — turn right
+static constexpr int BUTTON_VALUE_MIDDLE_RIGHT =
+    7; // physical 8 — also turn right
 
 /**
  * Returns true if the value corresponds to a known DOOM-mapped button.
  * Any value NOT in this set (e.g. -1, 10, 255) is treated as a release.
  */
-static bool isKnownDoomButton(int value)
-{
-    return value >= 0 && value <= 7;
-}
+static bool isKnownDoomButton(int value) { return value >= 0 && value <= 7; }
 
 /**
  * Returns true if the button should be a brief tap (auto-release after timer).
@@ -99,11 +98,9 @@ static bool isKnownDoomButton(int value)
  *   - Up (3): continuous move forward
  *   - Down (4): continuous move backward
  */
-static bool isTapButton(int value)
-{
-    return value == BUTTON_VALUE_MIDDLE_LEFT
-        || value == BUTTON_VALUE_MIDDLE_RIGHT
-        || value == BUTTON_VALUE_ENTER;
+static bool isTapButton(int value) {
+  return value == BUTTON_VALUE_MIDDLE_LEFT ||
+         value == BUTTON_VALUE_MIDDLE_RIGHT || value == BUTTON_VALUE_ENTER;
 }
 
 /* ============================================================
@@ -111,8 +108,10 @@ static bool isTapButton(int value)
  * ============================================================ */
 static DoomWorker *g_doomWorker = nullptr;
 
-static void platform_frame_callback(uint32_t *framebuffer, int width, int height);
-static int platform_getkey_callback(unsigned char *pressed, unsigned char *doomKey);
+static void platform_frame_callback(uint32_t *framebuffer, int width,
+                                    int height);
+static int platform_getkey_callback(unsigned char *pressed,
+                                    unsigned char *doomKey);
 
 /* ============================================================
  * Video subsystem state (replaces i_video.c)
@@ -137,7 +136,7 @@ extern "C" {
 
 /* Video buffers — screens[0] is the primary 8-bit indexed buffer */
 byte *I_VideoBuffer = NULL;
-byte *screens[5] = { NULL, NULL, NULL, NULL, NULL };
+byte *screens[5] = {NULL, NULL, NULL, NULL, NULL};
 
 /* Video settings referenced by the engine */
 int screenvisible = 1;
@@ -163,48 +162,40 @@ int mouse_threshold = 10;
  * ============================================================ */
 extern "C" {
 
-void DG_Init(void)
-{
-    fprintf(stderr, "[DOOM] Platform initialized (NERO Qt backend)\n");
+void DG_Init(void) {
+  fprintf(stderr, "[DOOM] Platform initialized (NERO Qt backend)\n");
 }
 
-void DG_DrawFrame(void)
-{
-    platform_frame_callback(DG_ScreenBuffer, DOOMGENERIC_RESX, DOOMGENERIC_RESY);
+void DG_DrawFrame(void) {
+  platform_frame_callback(DG_ScreenBuffer, DOOMGENERIC_RESX, DOOMGENERIC_RESY);
 }
 
-void DG_SleepMs(uint32_t ms)
-{
-    QThread::msleep(ms);
+void DG_SleepMs(uint32_t ms) { QThread::msleep(ms); }
+
+uint32_t DG_GetTicksMs(void) {
+  static QElapsedTimer timer;
+  static bool started = false;
+  if (!started) {
+    timer.start();
+    started = true;
+  }
+  return static_cast<uint32_t>(timer.elapsed());
 }
 
-uint32_t DG_GetTicksMs(void)
-{
-    static QElapsedTimer timer;
-    static bool started = false;
-    if (!started) {
-        timer.start();
-        started = true;
-    }
-    return static_cast<uint32_t>(timer.elapsed());
+int DG_GetKey(int *pressed, unsigned char *doom_key) {
+  unsigned char p = 0;
+  unsigned char k = 0;
+  int result = platform_getkey_callback(&p, &k);
+  if (result) {
+    *pressed = static_cast<int>(p);
+    *doom_key = k;
+    return 1;
+  }
+  return 0;
 }
 
-int DG_GetKey(int *pressed, unsigned char *doom_key)
-{
-    unsigned char p = 0;
-    unsigned char k = 0;
-    int result = platform_getkey_callback(&p, &k);
-    if (result) {
-        *pressed = static_cast<int>(p);
-        *doom_key = k;
-        return 1;
-    }
-    return 0;
-}
-
-void DG_SetWindowTitle(const char *title)
-{
-    fprintf(stderr, "[DOOM] Title: %s\n", title);
+void DG_SetWindowTitle(const char *title) {
+  fprintf(stderr, "[DOOM] Title: %s\n", title);
 }
 
 /* ============================================================
@@ -219,29 +210,24 @@ void DG_SetWindowTitle(const char *title)
  * Called once during engine startup.
  * Allocates the 8-bit indexed video buffer that DOOM renders to.
  */
-void I_InitGraphics(void)
-{
-    fprintf(stderr, "[DOOM] I_InitGraphics: NERO Qt backend (no /dev/fb0)\n");
-    // Allocate at DOOM's native render resolution (320x200), NOT at
-    // DOOMGENERIC_RESX x DOOMGENERIC_RESY (640x400). The engine's V_Init
-    // allocates screens[1..4] at 320x200, and wipe code calls I_ReadScreen
-    // expecting a 320x200 buffer. Using 640x400 here would overflow those
-    // destination buffers and crash during screen wipe transitions.
-    I_VideoBuffer = (byte *)Z_Malloc(320 * 200, PU_STATIC, NULL);
-    screens[0] = I_VideoBuffer;
-    fprintf(stderr, "[DOOM] I_InitGraphics: allocated 320x200 buffer at %p\n",
-            (void*)I_VideoBuffer);
+void I_InitGraphics(void) {
+  fprintf(stderr, "[DOOM] I_InitGraphics: NERO Qt backend (no /dev/fb0)\n");
+  // Allocate at DOOM's native render resolution (320x200), NOT at
+  // DOOMGENERIC_RESX x DOOMGENERIC_RESY (640x400). The engine's V_Init
+  // allocates screens[1..4] at 320x200, and wipe code calls I_ReadScreen
+  // expecting a 320x200 buffer. Using 640x400 here would overflow those
+  // destination buffers and crash during screen wipe transitions.
+  I_VideoBuffer = (byte *)Z_Malloc(320 * 200, PU_STATIC, NULL);
+  screens[0] = I_VideoBuffer;
+  fprintf(stderr, "[DOOM] I_InitGraphics: allocated 320x200 buffer at %p\n",
+          (void *)I_VideoBuffer);
 }
 
-void I_ShutdownGraphics(void)
-{
-    /* Z_Malloc'd memory is freed when the zone is destroyed */
+void I_ShutdownGraphics(void) {
+  /* Z_Malloc'd memory is freed when the zone is destroyed */
 }
 
-void I_StartFrame(void)
-{
-    /* Nothing needed — Qt handles frame timing */
-}
+void I_StartFrame(void) { /* Nothing needed — Qt handles frame timing */ }
 
 /**
  * Called each tick to process input events.
@@ -249,26 +235,21 @@ void I_StartFrame(void)
  * to the DOOM engine's event system via D_PostEvent.
  * Without this, keyboard/button input never reaches the game.
  */
-void I_StartTic(void)
-{
-    int pressed;
-    unsigned char doomKey;
+void I_StartTic(void) {
+  int pressed;
+  unsigned char doomKey;
 
-    while (DG_GetKey(&pressed, &doomKey))
-    {
-        event_t event;
-        event.type = pressed ? ev_keydown : ev_keyup;
-        event.data1 = doomKey;
-        event.data2 = -1;
-        event.data3 = -1;
-        D_PostEvent(&event);
-    }
+  while (DG_GetKey(&pressed, &doomKey)) {
+    event_t event;
+    event.type = pressed ? ev_keydown : ev_keyup;
+    event.data1 = doomKey;
+    event.data2 = -1;
+    event.data3 = -1;
+    D_PostEvent(&event);
+  }
 }
 
-void I_UpdateNoBlit(void)
-{
-    /* Nothing needed */
-}
+void I_UpdateNoBlit(void) { /* Nothing needed */ }
 
 /**
  * Called each frame after rendering is complete.
@@ -276,47 +257,42 @@ void I_UpdateNoBlit(void)
  * DG_ScreenBuffer using the current palette, then calls DG_DrawFrame
  * which hands the frame to Qt.
  */
-void I_FinishUpdate(void)
-{
-    if (!I_VideoBuffer || !DG_ScreenBuffer) return;
+void I_FinishUpdate(void) {
+  if (!I_VideoBuffer || !DG_ScreenBuffer)
+    return;
 
-    // DOOM renders at 320x200 (SCREENWIDTH x SCREENHEIGHT) into I_VideoBuffer.
-    // DG_ScreenBuffer is DOOMGENERIC_RESX x DOOMGENERIC_RESY (640x400).
-    // Scale each pixel to a 2x2 block.
-    for (int y = 0; y < 200; y++) {
-        for (int x = 0; x < 320; x++) {
-            uint32_t color = s_palette[I_VideoBuffer[y * 320 + x]];
-            DG_ScreenBuffer[(y * 2) * DOOMGENERIC_RESX + (x * 2)]         = color;
-            DG_ScreenBuffer[(y * 2) * DOOMGENERIC_RESX + (x * 2) + 1]     = color;
-            DG_ScreenBuffer[(y * 2 + 1) * DOOMGENERIC_RESX + (x * 2)]     = color;
-            DG_ScreenBuffer[(y * 2 + 1) * DOOMGENERIC_RESX + (x * 2) + 1] = color;
-        }
+  // DOOM renders at 320x200 (SCREENWIDTH x SCREENHEIGHT) into I_VideoBuffer.
+  // DG_ScreenBuffer is DOOMGENERIC_RESX x DOOMGENERIC_RESY (640x400).
+  // Scale each pixel to a 2x2 block.
+  for (int y = 0; y < 200; y++) {
+    for (int x = 0; x < 320; x++) {
+      uint32_t color = s_palette[I_VideoBuffer[y * 320 + x]];
+      DG_ScreenBuffer[(y * 2) * DOOMGENERIC_RESX + (x * 2)] = color;
+      DG_ScreenBuffer[(y * 2) * DOOMGENERIC_RESX + (x * 2) + 1] = color;
+      DG_ScreenBuffer[(y * 2 + 1) * DOOMGENERIC_RESX + (x * 2)] = color;
+      DG_ScreenBuffer[(y * 2 + 1) * DOOMGENERIC_RESX + (x * 2) + 1] = color;
     }
-    DG_DrawFrame();
+  }
+  DG_DrawFrame();
 }
 
 /**
  * Copy the current screen to a buffer (used for wipes/transitions).
  */
-void I_ReadScreen(byte *scr)
-{
-    memcpy(scr, I_VideoBuffer, 320 * 200);
-}
+void I_ReadScreen(byte *scr) { memcpy(scr, I_VideoBuffer, 320 * 200); }
 
 /**
  * Called when the engine changes the color palette.
  * Converts the 768-byte RGB palette (256 entries × 3 bytes) to
  * 32-bit XRGB values for fast lookup during I_FinishUpdate.
  */
-void I_SetPalette(byte *palette)
-{
-    fprintf(stderr, "[DOOM] I_SetPalette called\n");
-    for (int i = 0; i < 256; i++) {
-        s_palette[i] = (0xFF << 24)
-                      | (palette[i * 3 + 0] << 16)    /* R */
-                      | (palette[i * 3 + 1] << 8)     /* G */
-                      | (palette[i * 3 + 2]);          /* B */
-    }
+void I_SetPalette(byte *palette) {
+  fprintf(stderr, "[DOOM] I_SetPalette called\n");
+  for (int i = 0; i < 256; i++) {
+    s_palette[i] = (0xFF << 24) | (palette[i * 3 + 0] << 16) /* R */
+                   | (palette[i * 3 + 1] << 8)               /* G */
+                   | (palette[i * 3 + 2]);                   /* B */
+  }
 }
 
 /* ============================================================
@@ -327,50 +303,40 @@ void I_SetPalette(byte *palette)
 
 void I_BindVideoVariables(void) { /* nothing to bind */ }
 
-void I_SetWindowTitle(const char *title)
-{
-    fprintf(stderr, "[DOOM] I_SetWindowTitle: %s\n", title);
+void I_SetWindowTitle(const char *title) {
+  fprintf(stderr, "[DOOM] I_SetWindowTitle: %s\n", title);
 }
 
 void I_GraphicsCheckCommandLine(void) { /* no command line video args */ }
 
-void I_SetGrabMouseCallback(void (*func)(boolean grab))
-{
-    (void)func; /* no mouse grabbing in NERO */
+void I_SetGrabMouseCallback(void (*func)(boolean grab)) {
+  (void)func; /* no mouse grabbing in NERO */
 }
 
-void I_EnableLoadingDisk(int xoffs, int yoffs)
-{
-    (void)xoffs;
-    (void)yoffs;
+void I_EnableLoadingDisk(int xoffs, int yoffs) {
+  (void)xoffs;
+  (void)yoffs;
 }
 
-void I_DisplayFPSDots(boolean dots_on)
-{
-    (void)dots_on;
-}
+void I_DisplayFPSDots(boolean dots_on) { (void)dots_on; }
 
-boolean I_CheckIsScreensaver(void)
-{
-    return false;
-}
+boolean I_CheckIsScreensaver(void) { return false; }
 
-int I_GetPaletteIndex(int r, int g, int b)
-{
-    /* Find closest palette entry — simple nearest match */
-    int best = 0;
-    int bestDist = 0x7FFFFFFF;
-    for (int i = 0; i < 256; i++) {
-        int pr = (s_palette[i] >> 16) & 0xFF;
-        int pg = (s_palette[i] >> 8) & 0xFF;
-        int pb = s_palette[i] & 0xFF;
-        int dist = (r - pr) * (r - pr) + (g - pg) * (g - pg) + (b - pb) * (b - pb);
-        if (dist < bestDist) {
-            bestDist = dist;
-            best = i;
-        }
+int I_GetPaletteIndex(int r, int g, int b) {
+  /* Find closest palette entry — simple nearest match */
+  int best = 0;
+  int bestDist = 0x7FFFFFFF;
+  for (int i = 0; i < 256; i++) {
+    int pr = (s_palette[i] >> 16) & 0xFF;
+    int pg = (s_palette[i] >> 8) & 0xFF;
+    int pb = s_palette[i] & 0xFF;
+    int dist = (r - pr) * (r - pr) + (g - pg) * (g - pg) + (b - pb) * (b - pb);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = i;
     }
-    return best;
+  }
+  return best;
 }
 
 void I_BeginRead(void) { /* no loading disk icon */ }
@@ -382,25 +348,23 @@ void I_EndRead(void) { /* no loading disk icon */ }
  * Platform callback implementations
  * ============================================================ */
 
-static void platform_frame_callback(uint32_t *framebuffer, int width, int height)
-{
-    if (!g_doomWorker) return;
+static void platform_frame_callback(uint32_t *framebuffer, int width,
+                                    int height) {
+  if (!g_doomWorker)
+    return;
 
-    QImage frame(
-        reinterpret_cast<const uchar *>(framebuffer),
-        width,
-        height,
-        width * static_cast<int>(sizeof(uint32_t)),
-        QImage::Format_RGB32
-        );
+  QImage frame(reinterpret_cast<const uchar *>(framebuffer), width, height,
+               width * static_cast<int>(sizeof(uint32_t)),
+               QImage::Format_RGB32);
 
-    emit g_doomWorker->frameReady(frame.copy());
+  emit g_doomWorker->frameReady(frame.copy());
 }
 
-static int platform_getkey_callback(unsigned char *pressed, unsigned char *doomKey)
-{
-    if (!g_doomWorker) return 0;
-    return g_doomWorker->dequeueKey(pressed, doomKey);
+static int platform_getkey_callback(unsigned char *pressed,
+                                    unsigned char *doomKey) {
+  if (!g_doomWorker)
+    return 0;
+  return g_doomWorker->dequeueKey(pressed, doomKey);
 }
 
 /* ============================================================
@@ -408,30 +372,29 @@ static int platform_getkey_callback(unsigned char *pressed, unsigned char *doomK
  * ============================================================ */
 
 DoomImageProvider::DoomImageProvider()
-    : QQuickImageProvider(QQuickImageProvider::Image)
-    , m_currentFrame(320, 200, QImage::Format_RGB32)
-{
-    m_currentFrame.fill(Qt::black);
+    : QQuickImageProvider(QQuickImageProvider::Image),
+      m_currentFrame(320, 200, QImage::Format_RGB32) {
+  m_currentFrame.fill(Qt::black);
 }
 
-QImage DoomImageProvider::requestImage(const QString &id, QSize *size, const QSize &requestedSize)
-{
-    Q_UNUSED(id)
-    QMutexLocker lock(&m_mutex);
+QImage DoomImageProvider::requestImage(const QString &id, QSize *size,
+                                       const QSize &requestedSize) {
+  Q_UNUSED(id)
+  QMutexLocker lock(&m_mutex);
 
-    if (size)
-        *size = m_currentFrame.size();
+  if (size)
+    *size = m_currentFrame.size();
 
-    if (requestedSize.isValid() && requestedSize != m_currentFrame.size())
-        return m_currentFrame.scaled(requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+  if (requestedSize.isValid() && requestedSize != m_currentFrame.size())
+    return m_currentFrame.scaled(requestedSize, Qt::KeepAspectRatio,
+                                 Qt::SmoothTransformation);
 
-    return m_currentFrame;
+  return m_currentFrame;
 }
 
-void DoomImageProvider::updateFrame(const QImage &frame)
-{
-    QMutexLocker lock(&m_mutex);
-    m_currentFrame = frame;
+void DoomImageProvider::updateFrame(const QImage &frame) {
+  QMutexLocker lock(&m_mutex);
+  m_currentFrame = frame;
 }
 
 /* ============================================================
@@ -452,80 +415,64 @@ void DoomImageProvider::updateFrame(const QImage &frame)
  * ============================================================ */
 
 DoomWorker::DoomWorker(const QString &wadPath, QObject *parent)
-    : QObject(parent)
-    , m_wadPath(wadPath)
-    , m_running(false)
-{
+    : QObject(parent), m_wadPath(wadPath), m_running(false) {}
+
+DoomWorker::~DoomWorker() { stop(); }
+
+void DoomWorker::enqueueKey(const DoomKeyEvent &event) {
+  QMutexLocker lock(&m_keyMutex);
+  if (m_keyQueue.size() < 64) {
+    m_keyQueue.enqueue(event);
+  }
 }
 
-DoomWorker::~DoomWorker()
-{
-    stop();
+int DoomWorker::dequeueKey(unsigned char *pressed, unsigned char *doomKey) {
+  QMutexLocker lock(&m_keyMutex);
+  if (m_keyQueue.isEmpty())
+    return 0;
+
+  DoomKeyEvent event = m_keyQueue.dequeue();
+  *pressed = event.pressed;
+  *doomKey = event.doomKey;
+  return 1;
 }
 
-void DoomWorker::enqueueKey(const DoomKeyEvent &event)
-{
-    QMutexLocker lock(&m_keyMutex);
-    if (m_keyQueue.size() < 64) {
-        m_keyQueue.enqueue(event);
-    }
+void DoomWorker::start() {
+  if (m_running)
+    return;
+
+  g_doomWorker = this;
+
+  QByteArray wadPathUtf8 = m_wadPath.toUtf8();
+
+  char *argv[] = {const_cast<char *>("nero_doom"), const_cast<char *>("-iwad"),
+                  wadPathUtf8.data(), nullptr};
+  int argc = 3;
+
+  qInfo() << "[DOOM] Starting engine with WAD:" << m_wadPath;
+
+  doomgeneric_Create(argc, argv);
+
+  // Enable autorun (tricks engine into always run)
+  joybspeed = 29;
+
+  m_running = true;
+  emit started();
+
+  qInfo() << "[DOOM] Engine running, entering game loop";
+
+  // This loop blocks the worker thread until m_running is set to false
+  // by stop(), which is called from DoomController::stopGame()
+  while (m_running) {
+    doomgeneric_Tick();
+  }
+
+  qInfo() << "[DOOM] Game loop exited";
+  g_doomWorker = nullptr;
+  emit stopped();
 }
 
-int DoomWorker::dequeueKey(unsigned char *pressed, unsigned char *doomKey)
-{
-    QMutexLocker lock(&m_keyMutex);
-    if (m_keyQueue.isEmpty())
-        return 0;
-
-    DoomKeyEvent event = m_keyQueue.dequeue();
-    *pressed = event.pressed;
-    *doomKey = event.doomKey;
-    return 1;
-}
-
-void DoomWorker::start()
-{
-    if (m_running) return;
-
-    g_doomWorker = this;
-
-    QByteArray wadPathUtf8 = m_wadPath.toUtf8();
-
-    char *argv[] = {
-        const_cast<char *>("nero_doom"),
-        const_cast<char *>("-iwad"),
-        wadPathUtf8.data(),
-        nullptr
-    };
-    int argc = 3;
-
-    qInfo() << "[DOOM] Starting engine with WAD:" << m_wadPath;
-
-    doomgeneric_Create(argc, argv);
-
-    // Enable autorun (tricks engine into always run)
-    joybspeed = 29;
-
-    m_running = true;
-    emit started();
-
-    qInfo() << "[DOOM] Engine running, entering game loop";
-
-    // This loop blocks the worker thread until m_running is set to false
-    // by stop(), which is called from DoomController::stopGame()
-    while (m_running) {
-        doomgeneric_Tick();
-    }
-
-    qInfo() << "[DOOM] Game loop exited";
-    g_doomWorker = nullptr;
-    emit stopped();
-}
-
-void DoomWorker::stop()
-{
-    m_running = false;
-}
+void DoomWorker::stop() { m_running = false; }
 
 /* ============================================================
  * DoomController — Main QML-facing controller
@@ -539,154 +486,147 @@ void DoomWorker::stop()
  * ============================================================ */
 
 DoomController::DoomController(Model *model, QObject *parent)
-    : QObject(parent)
-    , m_model(model)
-    , m_worker(nullptr)
-    , m_gameThread(nullptr)
-    , m_imageProvider(nullptr)
-    , m_running(false)
-    , m_frameCounter(0)
-    , m_statusText("Press ENTER to start DOOM")
-    , m_lastButtonValue(-1)
-{
-    QStringList wadSearchPaths = {
-        QCoreApplication::applicationDirPath() + "/DOOM1.WAD",
-        QCoreApplication::applicationDirPath() + "/doom1.wad",
-        QDir::currentPath() + "/DOOM1.WAD",
-        QDir::currentPath() + "/doom1.wad",
-        "/opt/nero/DOOM1.WAD",
-        "/usr/share/doom/DOOM1.WAD",
-    };
+    : QObject(parent), m_model(model), m_worker(nullptr), m_gameThread(nullptr),
+      m_imageProvider(nullptr), m_running(false), m_frameCounter(0),
+      m_statusText("Press ENTER to start DOOM"), m_lastButtonValue(-1) {
+  QStringList wadSearchPaths = {
+      QCoreApplication::applicationDirPath() + "/DOOM1.WAD",
+      QCoreApplication::applicationDirPath() + "/doom1.wad",
+      QDir::currentPath() + "/DOOM1.WAD",
+      QDir::currentPath() + "/doom1.wad",
+      "/opt/nero/DOOM1.WAD",
+      "/usr/share/doom/DOOM1.WAD",
+  };
 
-    for (const QString &path : wadSearchPaths) {
-        if (QFile::exists(path)) {
-            m_wadPath = path;
-            qInfo() << "[DOOM] Found WAD file:" << path;
-            break;
-        }
+  for (const QString &path : wadSearchPaths) {
+    if (QFile::exists(path)) {
+      m_wadPath = path;
+      qInfo() << "[DOOM] Found WAD file:" << path;
+      break;
     }
+  }
 
-    if (m_wadPath.isEmpty()) {
-        qWarning() << "[DOOM] WAD file not found! Searched:" << wadSearchPaths;
-        m_statusText = "DOOM1.WAD not found!";
-    }
+  if (m_wadPath.isEmpty()) {
+    qWarning() << "[DOOM] WAD file not found! Searched:" << wadSearchPaths;
+    m_statusText = "DOOM1.WAD not found!";
+  }
 
-    // Connect to model data changes for hardware button input.
-    // We read the raw button value directly (not via the consume-on-read
-    // getXButtonPressed() methods) because DOOM needs both press AND release
-    // events, while the existing ButtonController pattern only fires on press.
-    connect(m_model, &Model::onCurrentDataChange, this, &DoomController::onDataChanged);
+  // Connect to model data changes for hardware button input.
+  // We read the raw button value directly (not via the consume-on-read
+  // getXButtonPressed() methods) because DOOM needs both press AND release
+  // events, while the existing ButtonController pattern only fires on press.
+  connect(m_model, &Model::onCurrentDataChange, this,
+          &DoomController::onDataChanged);
 
-    // Auto-release timer: the wheel hardware does NOT send button release
-    // events to MQTT. Without this timer, keys would stay held in DOOM
-    // forever after a single press. The timer sends keyup after 100ms,
-    // giving DOOM a few frames to register the press as a tap.
-    m_releaseTimer = new QTimer(this);
-    m_releaseTimer->setSingleShot(true);
-    m_releaseTimer->setInterval(100);
-    connect(m_releaseTimer, &QTimer::timeout, this, &DoomController::autoRelease);
+  // Auto-release timer: the wheel hardware does NOT send button release
+  // events to MQTT. Without this timer, keys would stay held in DOOM
+  // forever after a single press. The timer sends keyup after 100ms,
+  // giving DOOM a few frames to register the press as a tap.
+  m_releaseTimer = new QTimer(this);
+  m_releaseTimer->setSingleShot(true);
+  m_releaseTimer->setInterval(100);
+  connect(m_releaseTimer, &QTimer::timeout, this, &DoomController::autoRelease);
 }
 
-DoomController::~DoomController()
-{
-    stopGame();
+DoomController::~DoomController() { stopGame(); }
+
+DoomImageProvider *DoomController::createImageProvider() {
+  m_imageProvider = new DoomImageProvider();
+  return m_imageProvider;
 }
 
-DoomImageProvider *DoomController::createImageProvider()
-{
-    m_imageProvider = new DoomImageProvider();
-    return m_imageProvider;
-}
+void DoomController::startGame() {
+  if (m_running)
+    return;
 
-void DoomController::startGame()
-{
-    if (m_running) return;
-
-    if (m_wadPath.isEmpty()) {
-        m_statusText = "Cannot start: DOOM1.WAD not found";
-        emit statusTextChanged();
-        return;
-    }
-
-    qInfo() << "[DOOM] Starting game...";
-    m_statusText = "Loading DOOM...";
+  if (m_wadPath.isEmpty()) {
+    m_statusText = "Cannot start: DOOM1.WAD not found";
     emit statusTextChanged();
+    return;
+  }
 
-    // Reset button state on game start
-    m_lastButtonValue = -1;
+  qInfo() << "[DOOM] Starting game...";
+  m_statusText = "Loading DOOM...";
+  emit statusTextChanged();
 
-    m_gameThread = new QThread(this);
-    m_worker = new DoomWorker(m_wadPath);
-    m_worker->moveToThread(m_gameThread);
+  // Reset button state on game start
+  m_lastButtonValue = -1;
 
-    // Wire up thread lifecycle:
-    //   thread started → worker starts game loop
-    //   worker stopped → thread quits its event loop
-    //   thread finished → worker is deleted
-    connect(m_gameThread, &QThread::started, m_worker, &DoomWorker::start);
-    connect(m_worker, &DoomWorker::frameReady, this, &DoomController::onFrameReady, Qt::QueuedConnection);
-    connect(m_worker, &DoomWorker::started, this, &DoomController::onWorkerStarted, Qt::QueuedConnection);
-    connect(m_worker, &DoomWorker::stopped, this, &DoomController::onWorkerStopped, Qt::QueuedConnection);
+  m_gameThread = new QThread(this);
+  m_worker = new DoomWorker(m_wadPath);
+  m_worker->moveToThread(m_gameThread);
 
-    connect(m_worker, &DoomWorker::stopped, m_gameThread, &QThread::quit);
-    connect(m_gameThread, &QThread::finished, m_worker, &QObject::deleteLater);
+  // Wire up thread lifecycle:
+  //   thread started → worker starts game loop
+  //   worker stopped → thread quits its event loop
+  //   thread finished → worker is deleted
+  connect(m_gameThread, &QThread::started, m_worker, &DoomWorker::start);
+  connect(m_worker, &DoomWorker::frameReady, this,
+          &DoomController::onFrameReady, Qt::QueuedConnection);
+  connect(m_worker, &DoomWorker::started, this,
+          &DoomController::onWorkerStarted, Qt::QueuedConnection);
+  connect(m_worker, &DoomWorker::stopped, this,
+          &DoomController::onWorkerStopped, Qt::QueuedConnection);
 
-    m_gameThread->start();
+  connect(m_worker, &DoomWorker::stopped, m_gameThread, &QThread::quit);
+  connect(m_gameThread, &QThread::finished, m_worker, &QObject::deleteLater);
+
+  m_gameThread->start();
 }
 
-void DoomController::stopGame()
-{
-    if (!m_running || !m_worker) return;
+void DoomController::stopGame() {
+  if (!m_running || !m_worker)
+    return;
 
-    qInfo() << "[DOOM] Stopping game...";
+  qInfo() << "[DOOM] Stopping game...";
 
-    // Signal the game loop to exit
-    m_worker->stop();
+  // Signal the game loop to exit
+  m_worker->stop();
 
-    if (m_gameThread) {
-        // Ask the thread's event loop to quit
-        m_gameThread->quit();
+  if (m_gameThread) {
+    // Ask the thread's event loop to quit
+    m_gameThread->quit();
 
-        // Wait up to 3 seconds for the game loop to finish
-        m_gameThread->wait(3000);
+    // Wait up to 3 seconds for the game loop to finish
+    m_gameThread->wait(3000);
 
-        // If still running after 3s, force kill as a last resort
-        if (m_gameThread->isRunning()) {
-            qWarning() << "[DOOM] Force terminating game thread";
-            m_gameThread->terminate();
-            m_gameThread->wait(1000);
-        }
+    // If still running after 3s, force kill as a last resort
+    if (m_gameThread->isRunning()) {
+      qWarning() << "[DOOM] Force terminating game thread";
+      m_gameThread->terminate();
+      m_gameThread->wait(1000);
     }
+  }
 
-    m_running = false;
-    m_lastButtonValue = -1;
-    m_releaseTimer->stop();
-    m_statusText = "Press ENTER to start DOOM";
-    emit runningChanged();
-    emit statusTextChanged();
+  m_running = false;
+  m_lastButtonValue = -1;
+  m_releaseTimer->stop();
+  m_statusText = "Press ENTER to start DOOM";
+  emit runningChanged();
+  emit statusTextChanged();
 }
 
-void DoomController::sendKey(int doomKeyCode, bool pressed)
-{
-    if (!m_worker || !m_running) return;
+void DoomController::sendKey(int doomKeyCode, bool pressed) {
+  if (!m_worker || !m_running)
+    return;
 
-    DoomKeyEvent event;
-    event.pressed = pressed ? 1 : 0;
-    event.doomKey = static_cast<unsigned char>(doomKeyCode);
-    m_worker->enqueueKey(event);
+  DoomKeyEvent event;
+  event.pressed = pressed ? 1 : 0;
+  event.doomKey = static_cast<unsigned char>(doomKeyCode);
+  m_worker->enqueueKey(event);
 }
 
-void DoomController::onNeroButton(const QString &buttonName, bool pressed)
-{
-    unsigned char doomKey = mapNeroButtonToDoomKey(buttonName);
-    if (doomKey == 0) return;
+void DoomController::onNeroButton(const QString &buttonName, bool pressed) {
+  unsigned char doomKey = mapNeroButtonToDoomKey(buttonName);
+  if (doomKey == 0)
+    return;
 
-    if (!m_running && pressed && buttonName == "Enter") {
-        startGame();
-        return;
-    }
+  if (!m_running && pressed && buttonName == "Enter") {
+    startGame();
+    return;
+  }
 
-    sendKey(doomKey, pressed);
+  sendKey(doomKey, pressed);
 }
 
 /* ============================================================
@@ -710,46 +650,48 @@ void DoomController::onNeroButton(const QString &buttonName, bool pressed)
  *   0=esc, 1=left, 2=mid-left, 3=up, 4=down, 5=enter, 6=right, 7=mid-right
  * ============================================================ */
 
-void DoomController::onDataChanged()
-{
-    if (!m_running) return;
+void DoomController::onDataChanged() {
+  if (!m_running)
+    return;
 
-    std::optional<float> raw = m_model->getById(FORWARDBUTTON);
-    if (!raw.has_value()) return;
+  std::optional<float> raw = m_model->getById(FORWARDBUTTON);
+  if (!raw.has_value())
+    return;
 
-    int currentValue = static_cast<int>(*raw);
+  int currentValue = static_cast<int>(*raw);
 
-    // No change from last processed value — nothing to do
-    if (currentValue == m_lastButtonValue) return;
+  // No change from last processed value — nothing to do
+  if (currentValue == m_lastButtonValue)
+    return;
 
-    // Escape button (0) — stop DOOM and go home immediately
-    if (currentValue == BUTTON_VALUE_ESCAPE) {
-        m_releaseTimer->stop();
-        releaseCurrentButton();
-        m_lastButtonValue = currentValue;
-        stopGame();
-        emit escapeRequested();
-        return;
+  // Escape button (0) — stop DOOM and go home immediately
+  if (currentValue == BUTTON_VALUE_ESCAPE) {
+    m_releaseTimer->stop();
+    releaseCurrentButton();
+    m_lastButtonValue = currentValue;
+    stopGame();
+    emit escapeRequested();
+    return;
+  }
+
+  // Known button pressed → release old, press new
+  if (isKnownDoomButton(currentValue)) {
+    m_releaseTimer->stop();
+    releaseCurrentButton();
+    pressButton(currentValue);
+    m_lastButtonValue = currentValue;
+
+    // Tap buttons: auto-release after 100ms (single shot)
+    // Toggle buttons: stay held until a different button is pressed
+    if (isTapButton(currentValue)) {
+      m_releaseTimer->start();
     }
-
-    // Known button pressed → release old, press new
-    if (isKnownDoomButton(currentValue)) {
-        m_releaseTimer->stop();
-        releaseCurrentButton();
-        pressButton(currentValue);
-        m_lastButtonValue = currentValue;
-
-        // Tap buttons: auto-release after 100ms (single shot)
-        // Toggle buttons: stay held until a different button is pressed
-        if (isTapButton(currentValue)) {
-            m_releaseTimer->start();
-        }
-    } else {
-        // Non-button value (release event, if hardware sends one)
-        m_releaseTimer->stop();
-        releaseCurrentButton();
-        m_lastButtonValue = currentValue;
-    }
+  } else {
+    // Non-button value (release event, if hardware sends one)
+    m_releaseTimer->stop();
+    releaseCurrentButton();
+    m_lastButtonValue = currentValue;
+  }
 }
 
 /**
@@ -758,91 +700,102 @@ void DoomController::onDataChanged()
  * Does NOT reset m_lastButtonValue — the stale MQTT value must
  * not be re-detected as a new press.
  */
-void DoomController::autoRelease()
-{
-    releaseCurrentButton();
-    // m_lastButtonValue intentionally NOT reset.
-    // It stays at the button value so the stale MQTT value
-    // doesn't trigger phantom re-presses.
+void DoomController::autoRelease() {
+  releaseCurrentButton();
+  // m_lastButtonValue intentionally NOT reset.
+  // It stays at the button value so the stale MQTT value
+  // doesn't trigger phantom re-presses.
 }
 
-void DoomController::releaseCurrentButton()
-{
-    if (!isKnownDoomButton(m_lastButtonValue)) return;
+void DoomController::releaseCurrentButton() {
+  if (!isKnownDoomButton(m_lastButtonValue))
+    return;
 
-    if (m_lastButtonValue == BUTTON_VALUE_ENTER) {
-        sendKey(KEY_ENTER, false);
-        sendKey(KEY_FIRE, false);
-        sendKey(KEY_USE, false);
-    } else {
-        unsigned char key = mapButtonValueToDoomKey(m_lastButtonValue);
-        if (key != 0) sendKey(key, false);
-    }
+  if (m_lastButtonValue == BUTTON_VALUE_ENTER) {
+    sendKey(KEY_ENTER, false);
+    sendKey(KEY_FIRE, false);
+    sendKey(KEY_USE, false);
+  } else {
+    unsigned char key = mapButtonValueToDoomKey(m_lastButtonValue);
+    if (key != 0)
+      sendKey(key, false);
+  }
 }
 
-void DoomController::pressButton(int value)
-{
-    if (value == BUTTON_VALUE_ENTER) {
-        sendKey(KEY_ENTER, true);
-        sendKey(KEY_FIRE, true);
-        sendKey(KEY_USE, true);
-    } else {
-        unsigned char key = mapButtonValueToDoomKey(value);
-        if (key != 0) sendKey(key, true);
-    }
+void DoomController::pressButton(int value) {
+  if (value == BUTTON_VALUE_ENTER) {
+    sendKey(KEY_ENTER, true);
+    sendKey(KEY_FIRE, true);
+    sendKey(KEY_USE, true);
+  } else {
+    unsigned char key = mapButtonValueToDoomKey(value);
+    if (key != 0)
+      sendKey(key, true);
+  }
 }
 
 /**
  * Maps raw MQTT button values to DOOM key codes.
  * Values come from "Wheel/Buttons/button_id" topic.
  */
-unsigned char DoomController::mapButtonValueToDoomKey(int value)
-{
-    switch (value) {
-        case BUTTON_VALUE_LEFT:         return KEY_LEFTARROW;   // phys 2 — turn left
-        case BUTTON_VALUE_MIDDLE_LEFT:  return KEY_LEFTARROW;   // phys 3 — also turn left
-        case BUTTON_VALUE_UP:           return KEY_UPARROW;     // phys 4 — move forward
-        case BUTTON_VALUE_DOWN:         return KEY_DOWNARROW;   // phys 5 — move backward
-        case BUTTON_VALUE_ENTER:        return KEY_ENTER;       // phys 6 — handled specially
-        case BUTTON_VALUE_RIGHT:        return KEY_RIGHTARROW;  // phys 7 — turn right
-        case BUTTON_VALUE_MIDDLE_RIGHT: return KEY_RIGHTARROW;  // phys 8 — also turn right
-        default: return 0;
-    }
-}
-
-void DoomController::onFrameReady(const QImage &frame)
-{
-    if (m_imageProvider) {
-        m_imageProvider->updateFrame(frame);
-    }
-    m_frameCounter++;
-    emit frameCounterChanged();
-}
-
-void DoomController::onWorkerStarted()
-{
-    m_running = true;
-    m_statusText = "DOOM is running";
-    emit runningChanged();
-    emit statusTextChanged();
-}
-
-void DoomController::onWorkerStopped()
-{
-    m_running = false;
-    m_statusText = "Press ENTER to start DOOM";
-    emit runningChanged();
-    emit statusTextChanged();
-}
-
-unsigned char DoomController::mapNeroButtonToDoomKey(const QString &buttonName)
-{
-    if (buttonName == "Forward")    return KEY_UPARROW;
-    if (buttonName == "Backward")   return KEY_DOWNARROW;
-    if (buttonName == "Left")       return KEY_LEFTARROW;
-    if (buttonName == "Right")      return KEY_RIGHTARROW;
-    if (buttonName == "Enter")      return KEY_USE;
-    if (buttonName == "Up")         return KEY_FIRE;
-    if (buttonName == "Down")       return KEY_TAB;
+unsigned char DoomController::mapButtonValueToDoomKey(int value) {
+  switch (value) {
+  case BUTTON_VALUE_LEFT:
+    return KEY_LEFTARROW; // phys 2 — turn left
+  case BUTTON_VALUE_MIDDLE_LEFT:
+    return KEY_LEFTARROW; // phys 3 — also turn left
+  case BUTTON_VALUE_UP:
+    return KEY_UPARROW; // phys 4 — move forward
+  case BUTTON_VALUE_DOWN:
+    return KEY_DOWNARROW; // phys 5 — move backward
+  case BUTTON_VALUE_ENTER:
+    return KEY_ENTER; // phys 6 — handled specially
+  case BUTTON_VALUE_RIGHT:
+    return KEY_RIGHTARROW; // phys 7 — turn right
+  case BUTTON_VALUE_MIDDLE_RIGHT:
+    return KEY_RIGHTARROW; // phys 8 — also turn right
+  default:
     return 0;
+  }
+}
+
+void DoomController::onFrameReady(const QImage &frame) {
+  if (m_imageProvider) {
+    m_imageProvider->updateFrame(frame);
+  }
+  m_frameCounter++;
+  emit frameCounterChanged();
+}
+
+void DoomController::onWorkerStarted() {
+  m_running = true;
+  m_statusText = "DOOM is running";
+  emit runningChanged();
+  emit statusTextChanged();
+}
+
+void DoomController::onWorkerStopped() {
+  m_running = false;
+  m_statusText = "Press ENTER to start DOOM";
+  emit runningChanged();
+  emit statusTextChanged();
+}
+
+unsigned char
+DoomController::mapNeroButtonToDoomKey(const QString &buttonName) {
+  if (buttonName == "Forward")
+    return KEY_UPARROW;
+  if (buttonName == "Backward")
+    return KEY_DOWNARROW;
+  if (buttonName == "Left")
+    return KEY_LEFTARROW;
+  if (buttonName == "Right")
+    return KEY_RIGHTARROW;
+  if (buttonName == "Enter")
+    return KEY_USE;
+  if (buttonName == "Up")
+    return KEY_FIRE;
+  if (buttonName == "Down")
+    return KEY_TAB;
+  return 0;
 }

--- a/NERODevelopment/src/controllers/doomcontroller.h
+++ b/NERODevelopment/src/controllers/doomcontroller.h
@@ -22,47 +22,48 @@
  *   detection — tracking transitions to generate press/release pairs.
  *
  * Thread lifecycle:
- *   startGame() creates a QThread + DoomWorker, moves worker to thread, starts it.
- *   stopGame() sets m_running=false → game loop exits → thread quits → worker deleted.
- *   The thread is guaranteed to be stopped when:
+ *   startGame() creates a QThread + DoomWorker, moves worker to thread, starts
+ * it. stopGame() sets m_running=false → game loop exits → thread quits → worker
+ * deleted. The thread is guaranteed to be stopped when:
  *     - User presses Esc (DoomView.qml calls stopGame + goHome)
  *     - User navigates away (DoomView.qml onIsFocusedChanged calls stopGame)
  *     - DoomView.qml is destroyed (Component.onDestruction calls stopGame)
  *     - DoomController is destroyed (destructor calls stopGame)
  */
 
-#include <QObject>
-#include <QThread>
+#include <QElapsedTimer>
 #include <QImage>
 #include <QMutex>
+#include <QObject>
 #include <QQueue>
 #include <QQuickImageProvider>
-#include <QElapsedTimer>
+#include <QThread>
 #include <QTimer>
 
 #include "../models/model.h"
 
 struct DoomKeyEvent {
-    unsigned char pressed;
-    unsigned char doomKey;
+  unsigned char pressed;
+  unsigned char doomKey;
 };
 
 /**
  * @brief Image provider that serves the current DOOM frame to QML.
  *
- * QML references frames via: Image { source: "image://doom/frame?" + frameCounter }
- * The changing query param forces QML to re-request each new frame.
+ * QML references frames via: Image { source: "image://doom/frame?" +
+ * frameCounter } The changing query param forces QML to re-request each new
+ * frame.
  */
-class DoomImageProvider : public QQuickImageProvider
-{
+class DoomImageProvider : public QQuickImageProvider {
 public:
-    DoomImageProvider();
-    QImage requestImage(const QString &id, QSize *size, const QSize &requestedSize) override;
-    void updateFrame(const QImage &frame);
+  DoomImageProvider();
+  QImage requestImage(const QString &id, QSize *size,
+                      const QSize &requestedSize) override;
+  void updateFrame(const QImage &frame);
 
 private:
-    QImage m_currentFrame;
-    QMutex m_mutex;
+  QImage m_currentFrame;
+  QMutex m_mutex;
 };
 
 /**
@@ -72,107 +73,105 @@ private:
  * thread finishes (via QThread::finished → deleteLater connection).
  * The game loop in start() blocks until stop() sets m_running to false.
  */
-class DoomWorker : public QObject
-{
-    Q_OBJECT
+class DoomWorker : public QObject {
+  Q_OBJECT
 
 public:
-    explicit DoomWorker(const QString &wadPath, QObject *parent = nullptr);
-    ~DoomWorker();
+  explicit DoomWorker(const QString &wadPath, QObject *parent = nullptr);
+  ~DoomWorker();
 
-    void enqueueKey(const DoomKeyEvent &event);
-    int dequeueKey(unsigned char *pressed, unsigned char *doomKey);
+  void enqueueKey(const DoomKeyEvent &event);
+  int dequeueKey(unsigned char *pressed, unsigned char *doomKey);
 
 public slots:
-    void start();
-    void stop();
+  void start();
+  void stop();
 
 signals:
-    void frameReady(const QImage &frame);
-    void started();
-    void stopped();
+  void frameReady(const QImage &frame);
+  void started();
+  void stopped();
 
 private:
-    QString m_wadPath;
-    volatile bool m_running;
-    QQueue<DoomKeyEvent> m_keyQueue;
-    QMutex m_keyMutex;
+  QString m_wadPath;
+  volatile bool m_running;
+  QQueue<DoomKeyEvent> m_keyQueue;
+  QMutex m_keyMutex;
 };
 
 /**
  * @brief Main controller for DOOM in the NERO dashboard.
  *        Same pattern as FlappyBirdController and SnakeController.
  */
-class DoomController : public QObject
-{
-    Q_OBJECT
+class DoomController : public QObject {
+  Q_OBJECT
 
-    Q_PROPERTY(bool running READ running NOTIFY runningChanged)
-    Q_PROPERTY(int frameCounter READ frameCounter NOTIFY frameCounterChanged)
-    Q_PROPERTY(QString statusText READ statusText NOTIFY statusTextChanged)
+  Q_PROPERTY(bool running READ running NOTIFY runningChanged)
+  Q_PROPERTY(int frameCounter READ frameCounter NOTIFY frameCounterChanged)
+  Q_PROPERTY(QString statusText READ statusText NOTIFY statusTextChanged)
 
 public:
-    explicit DoomController(Model *model, QObject *parent = nullptr);
-    ~DoomController();
+  explicit DoomController(Model *model, QObject *parent = nullptr);
+  ~DoomController();
 
-    bool running() const { return m_running; }
-    int frameCounter() const { return m_frameCounter; }
-    QString statusText() const { return m_statusText; }
+  bool running() const { return m_running; }
+  int frameCounter() const { return m_frameCounter; }
+  QString statusText() const { return m_statusText; }
 
-    DoomImageProvider *createImageProvider();
+  DoomImageProvider *createImageProvider();
 
-    Q_INVOKABLE void startGame();
-    Q_INVOKABLE void stopGame();
-    Q_INVOKABLE void sendKey(int doomKeyCode, bool pressed);
-    Q_INVOKABLE void onNeroButton(const QString &buttonName, bool pressed);
+  Q_INVOKABLE void startGame();
+  Q_INVOKABLE void stopGame();
+  Q_INVOKABLE void sendKey(int doomKeyCode, bool pressed);
+  Q_INVOKABLE void onNeroButton(const QString &buttonName, bool pressed);
 
 signals:
-    void runningChanged();
-    void frameCounterChanged();
-    void statusTextChanged();
-    void escapeRequested();
+  void runningChanged();
+  void frameCounterChanged();
+  void statusTextChanged();
+  void escapeRequested();
 
 private slots:
-    void onFrameReady(const QImage &frame);
-    void onWorkerStarted();
-    void onWorkerStopped();
+  void onFrameReady(const QImage &frame);
+  void onWorkerStarted();
+  void onWorkerStopped();
 
-    /**
-     * @brief Called on every Model::onCurrentDataChange.
-     *
-     * Reads the raw value from "Wheel/Buttons/button_id" and compares
-     * against m_lastButtonValue to detect edges (press/release).
-     * Only processes buttons when DOOM is actively running.
-     */
-    void onDataChanged();
+  /**
+   * @brief Called on every Model::onCurrentDataChange.
+   *
+   * Reads the raw value from "Wheel/Buttons/button_id" and compares
+   * against m_lastButtonValue to detect edges (press/release).
+   * Only processes buttons when DOOM is actively running.
+   */
+  void onDataChanged();
 
 private:
-    unsigned char mapNeroButtonToDoomKey(const QString &buttonName);
-    unsigned char mapButtonValueToDoomKey(int value);
-    void releaseCurrentButton();
-    void pressButton(int value);
+  unsigned char mapNeroButtonToDoomKey(const QString &buttonName);
+  unsigned char mapButtonValueToDoomKey(int value);
+  void releaseCurrentButton();
+  void pressButton(int value);
 
-    /** Auto-releases the held key after a short delay */
-    void autoRelease();
+  /** Auto-releases the held key after a short delay */
+  void autoRelease();
 
-    Model *m_model;
-    DoomWorker *m_worker;
-    QThread *m_gameThread;
-    DoomImageProvider *m_imageProvider;
+  Model *m_model;
+  DoomWorker *m_worker;
+  QThread *m_gameThread;
+  DoomImageProvider *m_imageProvider;
 
-    bool m_running;
-    int m_frameCounter;
-    QString m_statusText;
-    QString m_wadPath;
+  bool m_running;
+  int m_frameCounter;
+  QString m_statusText;
+  QString m_wadPath;
 
-    // Edge detection for hardware buttons.
-    // Tracks the last raw value from "Wheel/Buttons/button_id".
-    int m_lastButtonValue;
+  // Edge detection for hardware buttons.
+  // Tracks the last raw value from "Wheel/Buttons/button_id".
+  int m_lastButtonValue;
 
-    // Auto-release timer: sends keyup after a brief delay so DOOM
-    // registers a tap instead of an infinite hold. Needed because
-    // the wheel hardware does not send release events to MQTT.
-    QTimer *m_releaseTimer;
+  // Auto-release timer: sends keyup after a brief delay so DOOM
+  // registers a tap instead of an infinite hold. Needed because
+  // the wheel hardware does not send release events to MQTT.
+  QTimer *m_releaseTimer;
 };
 
 #endif // DOOMCONTROLLER_H

--- a/NERODevelopment/src/controllers/offviewcontroller.cpp
+++ b/NERODevelopment/src/controllers/offviewcontroller.cpp
@@ -28,18 +28,15 @@ void OffViewController::update() {
     setAttributeStatus(SHUTDOWN_EFUSE,
                        static_cast<int>(AttributeStatus::FAULTED));
   } else if (shutdownEnabled && *shutdownEnabled == 1) {
-    setAttributeStatus(SHUTDOWN_EFUSE,
-                       static_cast<int>(AttributeStatus::GOOD));
+    setAttributeStatus(SHUTDOWN_EFUSE, static_cast<int>(AttributeStatus::GOOD));
   } else {
-    setAttributeStatus(SHUTDOWN_EFUSE,
-                       static_cast<int>(AttributeStatus::OFF));
+    setAttributeStatus(SHUTDOWN_EFUSE, static_cast<int>(AttributeStatus::OFF));
   }
 
   std::optional<float> mcFaulted = this->m_model->getById(EFUSE_MC_FAULTED);
   std::optional<float> mcEnabled = this->m_model->getById(EFUSE_MC_ENABLED);
   if (mcFaulted && *mcFaulted == 1) {
-    setAttributeStatus(MC_EFUSE,
-                       static_cast<int>(AttributeStatus::FAULTED));
+    setAttributeStatus(MC_EFUSE, static_cast<int>(AttributeStatus::FAULTED));
   } else if (mcEnabled && *mcEnabled == 1) {
     setAttributeStatus(MC_EFUSE, static_cast<int>(AttributeStatus::GOOD));
   } else {

--- a/NERODevelopment/src/main.cpp
+++ b/NERODevelopment/src/main.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR GPL-3.0-only
 
 #include "app_environment.h"
+#include "controllers/doomcontroller.h"
 #include "controllers/endurancecontroller.h"
 #include "controllers/flappybirdcontroller.h"
 #include "controllers/game2048controller.h"
@@ -11,8 +12,6 @@
 #include "controllers/offviewcontroller.h"
 #include "controllers/snakecontroller.h"
 #include "controllers/speedcontroller.h"
-#include "controllers/game2048controller.h"
-#include "controllers/doomcontroller.h"
 #include "import_qml_components_plugins.h"
 #include "import_qml_plugins.h"
 #include "models/raspberry_model.h"
@@ -21,59 +20,57 @@
 #include <QQmlContext>
 
 int main(int argc, char *argv[]) {
-    set_qt_environment();
+  set_qt_environment();
 
-    QGuiApplication app(argc, argv);
+  QGuiApplication app(argc, argv);
 
-    QQmlApplicationEngine engine;
+  QQmlApplicationEngine engine;
 
-    Model *model = new RaspberryModel();
-    model->connectToMQTT();
+  Model *model = new RaspberryModel();
+  model->connectToMQTT();
 
-    HomeController homeController(model);
-    HeaderController headerController(model);
-    OffViewController offViewController(model);
-    NavigationController navigationController(model);
-    FlappyBirdController flappyBirdController(model);
-    SnakeController snakeController(model);
-    DoomController doomController(model);
-    Game2048Controller game2048Controller(model);
-    EnduranceController enduranceController(model);
-    SpeedController speedController(model);
+  HomeController homeController(model);
+  HeaderController headerController(model);
+  OffViewController offViewController(model);
+  NavigationController navigationController(model);
+  FlappyBirdController flappyBirdController(model);
+  SnakeController snakeController(model);
+  DoomController doomController(model);
+  Game2048Controller game2048Controller(model);
+  EnduranceController enduranceController(model);
+  SpeedController speedController(model);
 
-    // Register DOOM's custom image provider with the QML engine.
-    // Unlike other controllers which just expose properties/methods to QML,
-    // DOOM renders frames to a raw pixel buffer that needs to be served to
-    // QML as an image. QQuickImageProvider lets QML load frames via:
-    //   Image { source: "image://doom/frame?" + frameCounter }
-    // The "doom" string here is the provider ID that maps to that URI scheme.
-    // This must be registered BEFORE engine.loadFromModule() so the QML
-    // engine can resolve "image://doom/..." when DoomView.qml is loaded.
-    engine.addImageProvider("doom", doomController.createImageProvider());
+  // Register DOOM's custom image provider with the QML engine.
+  // Unlike other controllers which just expose properties/methods to QML,
+  // DOOM renders frames to a raw pixel buffer that needs to be served to
+  // QML as an image. QQuickImageProvider lets QML load frames via:
+  //   Image { source: "image://doom/frame?" + frameCounter }
+  // The "doom" string here is the provider ID that maps to that URI scheme.
+  // This must be registered BEFORE engine.loadFromModule() so the QML
+  // engine can resolve "image://doom/..." when DoomView.qml is loaded.
+  engine.addImageProvider("doom", doomController.createImageProvider());
 
-    engine.rootContext()->setContextProperty("homeController", &homeController);
-    engine.rootContext()->setContextProperty("headerController",
-                                             &headerController);
-    engine.rootContext()->setContextProperty("offViewController",
-                                             &offViewController);
-    engine.rootContext()->setContextProperty("navigationController",
-                                             &navigationController);
-    engine.rootContext()->setContextProperty("flappyBirdController",
-                                             &flappyBirdController);
-    engine.rootContext()->setContextProperty("snakeController",
-                                             &snakeController);
-    engine.rootContext()->setContextProperty("doomController", &doomController);
-    engine.rootContext()->setContextProperty("game2048Controller",
-                                             &game2048Controller);
-    engine.rootContext()->setContextProperty("enduranceController",
-                                             &enduranceController);
-    engine.rootContext()->setContextProperty("speedController",
-                                             &speedController);
+  engine.rootContext()->setContextProperty("homeController", &homeController);
+  engine.rootContext()->setContextProperty("headerController",
+                                           &headerController);
+  engine.rootContext()->setContextProperty("offViewController",
+                                           &offViewController);
+  engine.rootContext()->setContextProperty("navigationController",
+                                           &navigationController);
+  engine.rootContext()->setContextProperty("flappyBirdController",
+                                           &flappyBirdController);
+  engine.rootContext()->setContextProperty("snakeController", &snakeController);
+  engine.rootContext()->setContextProperty("doomController", &doomController);
+  engine.rootContext()->setContextProperty("game2048Controller",
+                                           &game2048Controller);
+  engine.rootContext()->setContextProperty("enduranceController",
+                                           &enduranceController);
+  engine.rootContext()->setContextProperty("speedController", &speedController);
 
-    QObject::connect(
-        &engine, &QQmlApplicationEngine::objectCreationFailed, &app,
-        []() { QCoreApplication::exit(-1); }, Qt::QueuedConnection);
-    engine.loadFromModule("content", "App");
+  QObject::connect(
+      &engine, &QQmlApplicationEngine::objectCreationFailed, &app,
+      []() { QCoreApplication::exit(-1); }, Qt::QueuedConnection);
+  engine.loadFromModule("content", "App");
 
-    return app.exec();
+  return app.exec();
 }

--- a/NERODevelopment/src/models/raspberry_model.cpp
+++ b/NERODevelopment/src/models/raspberry_model.cpp
@@ -419,8 +419,7 @@ std::optional<float> RaspberryModel::getModeIndex() {
 void RaspberryModel::updateCurrentData() { emit this->onCurrentDataChange(); }
 
 QList<QString> RaspberryModel::getCriticalFaults() {
-  QRegularExpression regex(
-      "^(BMS/Faults/Critical/.*|VCU/Faults/Critical/.*)$");
+  QRegularExpression regex("^(BMS/Faults/Critical/.*|VCU/Faults/Critical/.*)$");
 
   QList<QString> faults;
 

--- a/NERODevelopment/src/utils/data_type_names.h
+++ b/NERODevelopment/src/utils/data_type_names.h
@@ -21,7 +21,8 @@
 #define MINCELLVOLTAGECELL "BMS/Cells/Volts_Low_Cell"
 #define AVECELLTEMP "BMS/Status/Temp_Average"
 #define AVECELLVOLTAGE "BMS/Cells/Volts_Avg_Value"
-// #define TRACTIONCONTROL "MPU/State/LaunchControl" // OUTDATED - see LAUNCHCONTROL and TRACTIONCONTROL
+// #define TRACTIONCONTROL "MPU/State/LaunchControl" // OUTDATED - see
+// LAUNCHCONTROL and TRACTIONCONTROL
 #define INVERTERTEMP "DTI/Temps/Controller_Temperature"
 #define BMSSTATE "BMS/Status/State"
 #define BMSFAULT "BMS/Faults/Critical/#"
@@ -37,8 +38,10 @@
 #define SEGMENTTEMP2 "BMS/Segment_Temp/2"
 #define SEGMENTTEMP3 "BMS/Segment_Temp/3"
 #define SEGMENTTEMP4 "BMS/Segment_Temp/4"
-// #define SIDEBRBS "MPU/Fuses/SD_TO_BRB_FUSE_STAT" // OUTDATED - see EFUSE_SHUTDOWN_ENABLED and EFUSE_SHUTDOWN_FAULTED
-// #define MPU "MPU/Shutdown/MC_STAT" // OUTDATED - see EFUSE_MC_ENABLED and EFUSE_MC_FAULTED
+// #define SIDEBRBS "MPU/Fuses/SD_TO_BRB_FUSE_STAT" // OUTDATED - see
+// EFUSE_SHUTDOWN_ENABLED and EFUSE_SHUTDOWN_FAULTED #define MPU
+// "MPU/Shutdown/MC_STAT" // OUTDATED - see EFUSE_MC_ENABLED and
+// EFUSE_MC_FAULTED
 #define CRITICALFAULTS "BMS/Faults/Critical/#"
 #define NONCRITICALFAULTS "BMS/Faults/Non-Critical/#"
 #define LOWVOLTAGESOC                                                          \


### PR DESCRIPTION
## Changes

Replaces the two independent fault alert flows with a single fault alert popup that lists every active fault together.  Critical faults are red and noncritical faults are blue (to eliminate confusion). Drops logic that was used for the old display paths.

## Screenshots

<img width="743" height="428" alt="Screenshot 2026-04-24 002522" src="https://github.com/user-attachments/assets/e24371f4-d9f6-40ad-9e52-ce868e605ed8" />

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #221