### PR TITLE
Low Voltage

### DIFF
--- a/NERODevelopment/content/EnduranceScreen.qml
+++ b/NERODevelopment/content/EnduranceScreen.qml
@@ -84,6 +84,8 @@ Item {
                 ThermometerValueComponent {
                     id: regen
                     regen: true
+                    unit: "A"
+                    unitAnchorBottom: true
                     thermometerValue: endurance.numRegen
                     title: "REGEN"
                     Layout.fillWidth: true

--- a/NERODevelopment/content/Pit.qml
+++ b/NERODevelopment/content/Pit.qml
@@ -8,7 +8,7 @@ Rectangle {
     id: pit
     anchors.fill: parent
     property int stateOfChargePercentage: homeController.stateOfCharge
-    property int lvStateOfChargePercentage: homeController.lowVoltageStateOfCharge
+    property real lvVoltage: homeController.lowVoltage
     property int packTempValue: homeController.packTemp
     property int motorTempValue: homeController.motorTemp
     property int currentSpeed: homeController.speed
@@ -117,12 +117,13 @@ Rectangle {
                     unitFontSize: pit.unitFontSize
                 }
 
-                BatteryValueComponent {
+                ThermometerValueComponent {
                     Layout.fillWidth: true
                     Layout.fillHeight: true
 
-                    batteryValue: pit.lvStateOfChargePercentage
-                    title: "LV SOC"
+                    thermometerValue: pit.lvVoltage
+                    title: "LV"
+                    unit: "V"
                     radius: pit.componentRadii
                     valueFontSize: pit.valueFontSize
                     labelFontSize: pit.labelFontSize

--- a/NERODevelopment/content/SpeedMode.qml
+++ b/NERODevelopment/content/SpeedMode.qml
@@ -92,6 +92,8 @@ Item {
                     valueFontSize: speedMode.valueFontSize
                     labelFontSize: speedMode.labelFontSize
                     regen: true
+                    unit: "A"
+                    unitAnchorBottom: true
                 }
 
                 ThermometerValueComponent {

--- a/NERODevelopment/content/ThermometerValueComponent.qml
+++ b/NERODevelopment/content/ThermometerValueComponent.qml
@@ -15,6 +15,8 @@ Item {
     property int valueFontSize
     property int labelFontSize
     property int unitFontSize: valueFontSize
+    property string unit: "°"
+    property bool unitAnchorBottom: false
 
     LabeledComponent {
         anchors.fill: parent
@@ -29,11 +31,11 @@ Item {
         labelVerticalSpacing: thermometerComponent.labelVerticalSpacing
         labelColor: thermometerComponent.labelColor
         horizontalPadding: thermometerComponent.horizontalPadding
-        valueUnit: regen ? "A" : "°"
+        valueUnit: thermometerComponent.unit
         radius: thermometerComponent.radius
         valueFontSize: thermometerComponent.valueFontSize
         labelFontSize: thermometerComponent.labelFontSize
         unitFontSize: thermometerComponent.unitFontSize
-        unitAnchorBottom: regen ? true : false
+        unitAnchorBottom: thermometerComponent.unitAnchorBottom
     }
 }

--- a/NERODevelopment/src/controllers/homecontroller.cpp
+++ b/NERODevelopment/src/controllers/homecontroller.cpp
@@ -62,14 +62,12 @@ void HomeController::setStateOfCharge(int charge) {
   }
 }
 
-int HomeController::lowVoltageStateOfCharge() const {
-  return m_lowVoltageStateOfCharge;
-}
+float HomeController::lowVoltage() const { return m_lowVoltage; }
 
-void HomeController::setLowVoltageStateOfCharge(int charge) {
-  if (charge != m_lowVoltageStateOfCharge) {
-    m_lowVoltageStateOfCharge = charge;
-    emit lowVoltageStateOfChargeChanged(charge);
+void HomeController::setLowVoltage(float voltage) {
+  if (voltage != m_lowVoltage) {
+    m_lowVoltage = voltage;
+    emit lowVoltageChanged(voltage);
   }
 }
 
@@ -81,6 +79,6 @@ void HomeController::currentDataDidChange() {
     setStateOfCharge(*m_model->getStateOfCharge());
     setSpeed(*m_model->getMph());
     setStatus(*m_model->getStatus());
-    setLowVoltageStateOfCharge(*m_model->getLowVoltageStateOfCharge());
+    setLowVoltage(*m_model->getLowVoltage());
   }
 }

--- a/NERODevelopment/src/controllers/homecontroller.h
+++ b/NERODevelopment/src/controllers/homecontroller.h
@@ -21,9 +21,8 @@ class HomeController : public ButtonController {
                  motorTempChanged FINAL)
   Q_PROPERTY(int stateOfCharge READ stateOfCharge WRITE setStateOfCharge NOTIFY
                  stateOfChargeChanged FINAL)
-  Q_PROPERTY(int lowVoltageStateOfCharge READ lowVoltageStateOfCharge WRITE
-                 setLowVoltageStateOfCharge NOTIFY
-                     lowVoltageStateOfChargeChanged FINAL)
+  Q_PROPERTY(float lowVoltage READ lowVoltage WRITE setLowVoltage NOTIFY
+                 lowVoltageChanged FINAL)
 
 public:
   explicit HomeController(Model *model, QObject *parent = nullptr);
@@ -33,7 +32,7 @@ public:
   float packTemp() const;
   float motorTemp() const;
   int stateOfCharge() const;
-  int lowVoltageStateOfCharge() const;
+  float lowVoltage() const;
 
 signals:
   void speedChanged(int);
@@ -42,7 +41,7 @@ signals:
   void packTempChanged(float);
   void motorTempChanged(float);
   void stateOfChargeChanged(int);
-  void lowVoltageStateOfChargeChanged(int);
+  void lowVoltageChanged(float);
 
 public slots:
   void setSpeed(int);
@@ -52,7 +51,7 @@ public slots:
   void setMotorTemp(float);
   void currentDataDidChange();
   void setStateOfCharge(int);
-  void setLowVoltageStateOfCharge(int);
+  void setLowVoltage(float);
 
 private:
   int m_speed;
@@ -61,7 +60,7 @@ private:
   float m_packTemp;
   float m_motorTemp;
   int m_stateOfCharge;
-  int m_lowVoltageStateOfCharge;
+  float m_lowVoltage;
 };
 
 #endif // HOMECONTROLLER_H

--- a/NERODevelopment/src/models/model.h
+++ b/NERODevelopment/src/models/model.h
@@ -76,7 +76,7 @@ public:
   virtual QList<QString> getCriticalFaults() = 0;
   virtual QList<QString> getNonCriticalFaults() = 0;
   virtual void sendMessage(QString topic, float value) = 0;
-  virtual std::optional<float> getLowVoltageStateOfCharge() = 0;
+  virtual std::optional<float> getLowVoltage() = 0;
 
   std::optional<int> getTime();
   std::optional<int> getFastestTime();

--- a/NERODevelopment/src/models/raspberry_model.cpp
+++ b/NERODevelopment/src/models/raspberry_model.cpp
@@ -93,7 +93,7 @@ void RaspberryModel::connectToMQTT() {
       HVCNCTR,
       CRITICALFAULTS,
       NONCRITICALFAULTS,
-      LOWVOLTAGESOC,
+      LVVOLTAGE,
 
   };
 
@@ -419,8 +419,7 @@ std::optional<float> RaspberryModel::getModeIndex() {
 void RaspberryModel::updateCurrentData() { emit this->onCurrentDataChange(); }
 
 QList<QString> RaspberryModel::getCriticalFaults() {
-  QRegularExpression regex(
-      "^(BMS/Faults/Critical/.*|VCU/Faults/Critical/.*)$");
+  QRegularExpression regex("^(BMS/Faults/Critical/.*|VCU/Faults/Critical/.*)$");
 
   QList<QString> faults;
 
@@ -461,6 +460,6 @@ int RaspberryModel::totalNumberOfOnesIn(float value) {
   return total;
 }
 
-std::optional<float> RaspberryModel::getLowVoltageStateOfCharge() {
-  return this->getById(LOWVOLTAGESOC);
+std::optional<float> RaspberryModel::getLowVoltage() {
+  return this->getById(LVVOLTAGE);
 }

--- a/NERODevelopment/src/models/raspberry_model.h
+++ b/NERODevelopment/src/models/raspberry_model.h
@@ -71,7 +71,7 @@ public:
   std::optional<float> getSegment4Temp() override;
   QList<QString> getCriticalFaults() override;
   QList<QString> getNonCriticalFaults() override;
-  std::optional<float> getLowVoltageStateOfCharge() override;
+  std::optional<float> getLowVoltage() override;
 
   void sendMessage(const QString topic, const float value) override;
 

--- a/NERODevelopment/src/utils/data_type_names.h
+++ b/NERODevelopment/src/utils/data_type_names.h
@@ -21,7 +21,8 @@
 #define MINCELLVOLTAGECELL "BMS/Cells/Volts_Low_Cell"
 #define AVECELLTEMP "BMS/Status/Temp_Average"
 #define AVECELLVOLTAGE "BMS/Cells/Volts_Avg_Value"
-// #define TRACTIONCONTROL "MPU/State/LaunchControl" // OUTDATED - see LAUNCHCONTROL and TRACTIONCONTROL
+// #define TRACTIONCONTROL "MPU/State/LaunchControl" // OUTDATED - see
+// LAUNCHCONTROL and TRACTIONCONTROL
 #define INVERTERTEMP "DTI/Temps/Controller_Temperature"
 #define BMSSTATE "BMS/Status/State"
 #define BMSFAULT "BMS/Faults/Critical/#"
@@ -37,13 +38,13 @@
 #define SEGMENTTEMP2 "BMS/Segment_Temp/2"
 #define SEGMENTTEMP3 "BMS/Segment_Temp/3"
 #define SEGMENTTEMP4 "BMS/Segment_Temp/4"
-// #define SIDEBRBS "MPU/Fuses/SD_TO_BRB_FUSE_STAT" // OUTDATED - see EFUSE_SHUTDOWN_ENABLED and EFUSE_SHUTDOWN_FAULTED
-// #define MPU "MPU/Shutdown/MC_STAT" // OUTDATED - see EFUSE_MC_ENABLED and EFUSE_MC_FAULTED
+// #define SIDEBRBS "MPU/Fuses/SD_TO_BRB_FUSE_STAT" // OUTDATED - see
+// EFUSE_SHUTDOWN_ENABLED and EFUSE_SHUTDOWN_FAULTED #define MPU
+// "MPU/Shutdown/MC_STAT" // OUTDATED - see EFUSE_MC_ENABLED and
+// EFUSE_MC_FAULTED
 #define CRITICALFAULTS "BMS/Faults/Critical/#"
 #define NONCRITICALFAULTS "BMS/Faults/Non-Critical/#"
-#define LOWVOLTAGESOC                                                          \
-  "MPU/Sense/SOC" // OUTDATED MPU TOPIC - no equivalent topic exists on VCU as
-                  // of right now.
+#define LVVOLTAGE "VCU/LV/voltage"
 
 /* VCU Topics */
 #define TORQUEPOWER "VCU/CarState/torque_limit_percentage"


### PR DESCRIPTION
## Changes

LVSOC topic no longer exists after the mpu was replaced by the vcu. The component was replaced with directly using the lower voltage. The component was also changed from a battery component to a thermometer component since it no longer uses percentages. `unit` and `unitAnchorBottom` properties were also decoupled from the regen flag.

## Screenshots

<img width="739" height="429" alt="Screenshot 2026-04-24 023136" src="https://github.com/user-attachments/assets/3871f5cb-a6fe-4c8d-920a-5fe8df5546fb" />

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #224
