### PR TITLE
Fault Toggles

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "deps/protobuf"]
 	path = deps/protobuf
 	url = https://github.com/protocolbuffers/protobuf
+[submodule "NERODevelopment/src/third_party/doomgeneric"]
+	path = NERODevelopment/src/third_party/doomgeneric
+	url = https://github.com/ozkl/doomgeneric.git

--- a/NERODevelopment/content/EnduranceScreen.qml
+++ b/NERODevelopment/content/EnduranceScreen.qml
@@ -30,6 +30,8 @@ Item {
     Keys.onPressed: event => {
         if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
             enduranceController.enterButtonPressed();
+        } else if (event.key === Qt.Key_Right) {
+            headerController.toggleFaultAlerts();
         }
     }
 

--- a/NERODevelopment/content/HeaderView.qml
+++ b/NERODevelopment/content/HeaderView.qml
@@ -9,6 +9,8 @@ Item {
 
     property var criticalFaults: headerController.criticalFaults
     property var nonCriticalFaults: headerController.nonCriticalFaults
+    property bool faultAlertsEnabled: headerController.faultAlertsEnabled
+    property bool ownsDialog: false
     property string modeTitle: ""
 
     Timer {
@@ -19,17 +21,26 @@ Item {
     }
 
     function refreshFaultDialog() {
+        if (!ownsDialog)
+            return;
+        if (!faultAlertsEnabled) {
+            faultDialog.close();
+            autoCloseTimer.stop();
+            return;
+        }
         if (criticalFaults.length === 0 && nonCriticalFaults.length === 0) {
             faultDialog.close();
             autoCloseTimer.stop();
             return;
         }
+        faultDialog.close();
         faultDialog.open();
         autoCloseTimer.restart();
     }
 
     onCriticalFaultsChanged: refreshFaultDialog()
     onNonCriticalFaultsChanged: refreshFaultDialog()
+    onFaultAlertsEnabledChanged: refreshFaultDialog()
 
     NonCriticalWarning {
         id: nonCriticalWarning

--- a/NERODevelopment/content/NavigationController.qml
+++ b/NERODevelopment/content/NavigationController.qml
@@ -37,6 +37,7 @@ Item {
 
     HeaderView {
         id: header
+        ownsDialog: true
     }
 
     LabelText {

--- a/NERODevelopment/content/Pit.qml
+++ b/NERODevelopment/content/Pit.qml
@@ -26,6 +26,12 @@ Rectangle {
     height: 480
     width: 800
 
+    Keys.onPressed: event => {
+        if (event.key === Qt.Key_Right) {
+            headerController.toggleFaultAlerts();
+        }
+    }
+
     ColumnLayout {
         anchors.fill: parent
         spacing: 0

--- a/NERODevelopment/content/SpeedMode.qml
+++ b/NERODevelopment/content/SpeedMode.qml
@@ -31,6 +31,8 @@ Item {
     Keys.onPressed: event => {
         if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
             speedController.enterButtonPressed();
+        } else if (event.key === Qt.Key_Right) {
+            headerController.toggleFaultAlerts();
         }
     }
 

--- a/NERODevelopment/src/controllers/endurancecontroller.cpp
+++ b/NERODevelopment/src/controllers/endurancecontroller.cpp
@@ -140,6 +140,10 @@ void EnduranceController::enterButtonPressed() {
   }
 }
 
+void EnduranceController::rightButtonPressed() {
+  emit toggleFaultAlertsRequested();
+}
+
 void EnduranceController::updateCurrentTime() {
   if (m_timerRunning) {
     setCurrentTime(static_cast<int>(m_timer.elapsed()));

--- a/NERODevelopment/src/controllers/endurancecontroller.h
+++ b/NERODevelopment/src/controllers/endurancecontroller.h
@@ -53,6 +53,7 @@ signals:
   void currentTimeChanged(int);
   void fastestTimeChanged(int);
   void lastTimeChanged(int);
+  void toggleFaultAlertsRequested();
 
 public slots:
   void setCurrentMaxTorque(int);
@@ -67,6 +68,7 @@ public slots:
   void setLastTime(int);
 
   void enterButtonPressed() override;
+  void rightButtonPressed() override;
   void updateCurrentTime();
 
 private:

--- a/NERODevelopment/src/controllers/headercontroller.cpp
+++ b/NERODevelopment/src/controllers/headercontroller.cpp
@@ -31,3 +31,12 @@ void HeaderController::currentDataDidChange() {
   setCriticalFaults(m_model->getCriticalFaults());
   setNonCriticalFaults(m_model->getNonCriticalFaults());
 }
+
+bool HeaderController::faultAlertsEnabled() const {
+  return m_faultAlertsEnabled;
+}
+
+void HeaderController::toggleFaultAlerts() {
+  m_faultAlertsEnabled = !m_faultAlertsEnabled;
+  emit faultAlertsEnabledChanged(m_faultAlertsEnabled);
+}

--- a/NERODevelopment/src/controllers/headercontroller.h
+++ b/NERODevelopment/src/controllers/headercontroller.h
@@ -14,25 +14,31 @@ class HeaderController : public QObject {
                  setCriticalFaults NOTIFY criticalFaultsChanged FINAL)
   Q_PROPERTY(QList<QString> nonCriticalFaults READ nonCriticalFaults WRITE
                  setNonCriticalFaults NOTIFY nonCriticalFaultsChanged FINAL)
+  Q_PROPERTY(bool faultAlertsEnabled READ faultAlertsEnabled NOTIFY
+                 faultAlertsEnabledChanged FINAL)
 
 public:
   explicit HeaderController(Model *model, QObject *parent = nullptr);
   QList<QString> criticalFaults() const;
   QList<QString> nonCriticalFaults() const;
+  bool faultAlertsEnabled() const;
 
 signals:
   void criticalFaultsChanged(QList<QString>);
   void nonCriticalFaultsChanged(QList<QString>);
+  void faultAlertsEnabledChanged(bool);
 
 public slots:
   void setCriticalFaults(QList<QString>);
   void setNonCriticalFaults(QList<QString>);
   void currentDataDidChange();
+  void toggleFaultAlerts();
 
 private:
   Model *m_model;
   QList<QString> m_criticalFaults;
   QList<QString> m_nonCriticalFaults;
+  bool m_faultAlertsEnabled = true;
 };
 
 #endif // HEADERCONTROLLER_H

--- a/NERODevelopment/src/controllers/homecontroller.cpp
+++ b/NERODevelopment/src/controllers/homecontroller.cpp
@@ -71,6 +71,8 @@ void HomeController::setLowVoltage(float voltage) {
   }
 }
 
+void HomeController::rightButtonPressed() { emit toggleFaultAlertsRequested(); }
+
 void HomeController::currentDataDidChange() {
   if (this->m_pageIndices.contains(this->m_model->currentPageIndex)) {
     setPackTemp(*m_model->getPackTemp());

--- a/NERODevelopment/src/controllers/homecontroller.h
+++ b/NERODevelopment/src/controllers/homecontroller.h
@@ -42,6 +42,7 @@ signals:
   void motorTempChanged(float);
   void stateOfChargeChanged(int);
   void lowVoltageChanged(float);
+  void toggleFaultAlertsRequested();
 
 public slots:
   void setSpeed(int);
@@ -52,6 +53,7 @@ public slots:
   void currentDataDidChange();
   void setStateOfCharge(int);
   void setLowVoltage(float);
+  void rightButtonPressed() override;
 
 private:
   int m_speed;

--- a/NERODevelopment/src/controllers/speedcontroller.cpp
+++ b/NERODevelopment/src/controllers/speedcontroller.cpp
@@ -137,6 +137,10 @@ void SpeedController::enterButtonPressed() {
   }
 }
 
+void SpeedController::rightButtonPressed() {
+  emit toggleFaultAlertsRequested();
+}
+
 void SpeedController::updateCurrentTime() {
   if (m_timerRunning) {
     setCurrentTime(static_cast<int>(m_timer.elapsed()));

--- a/NERODevelopment/src/controllers/speedcontroller.h
+++ b/NERODevelopment/src/controllers/speedcontroller.h
@@ -69,6 +69,7 @@ signals:
   void currentDischargeChanged(float);
   void maxCurrentDischargeChanged(float);
   void regenChanged(float);
+  void toggleFaultAlertsRequested();
 
 public slots:
   void setTractionControl(bool);
@@ -87,6 +88,7 @@ public slots:
   void setRegen(float);
 
   void enterButtonPressed() override;
+  void rightButtonPressed() override;
   void updateCurrentTime();
 
   void update();

--- a/NERODevelopment/src/main.cpp
+++ b/NERODevelopment/src/main.cpp
@@ -67,6 +67,15 @@ int main(int argc, char *argv[]) {
                                            &enduranceController);
   engine.rootContext()->setContextProperty("speedController", &speedController);
 
+  QObject::connect(&homeController, &HomeController::toggleFaultAlertsRequested,
+                   &headerController, &HeaderController::toggleFaultAlerts);
+  QObject::connect(&speedController,
+                   &SpeedController::toggleFaultAlertsRequested,
+                   &headerController, &HeaderController::toggleFaultAlerts);
+  QObject::connect(&enduranceController,
+                   &EnduranceController::toggleFaultAlertsRequested,
+                   &headerController, &HeaderController::toggleFaultAlerts);
+
   QObject::connect(
       &engine, &QQmlApplicationEngine::objectCreationFailed, &app,
       []() { QCoreApplication::exit(-1); }, Qt::QueuedConnection);


### PR DESCRIPTION
## Changes

Added ability to toggle the fault alerts. The ability to toggle only works in the two pit pages and the two drive modes (due to button limitations). The right key is used on other screens like off page, nav page, and games, and its better to prioritize toggling for driving/pit. Also previous when new faults were created, old fault alerts would just be overlapped and auto closed after 3 seconds. Now, on each new fault, the popup is explicitly closed and reopened

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #214 
