### PR TITLE
2048 saves

### DIFF
--- a/NERODevelopment/content/Game2048.qml
+++ b/NERODevelopment/content/Game2048.qml
@@ -9,7 +9,7 @@ Rectangle {
     property bool isFocused: false
     property var board: []
     property int score: 0
-    property int bestScore: 0
+    property int bestScore: game2048Controller.bestScore
     property bool hasWon: false
     property bool animating: false
     property var slotMap: ({})
@@ -250,8 +250,8 @@ Rectangle {
 
         slotMap = newSlotMap;
         score += totalMergeScore;
-        if (score > bestScore)
-            bestScore = score;
+        if (score > game2048Controller.bestScore)
+            game2048Controller.setBestScore(score);
 
         animTimer.toRelease = toRelease;
         animTimer.start();
@@ -296,7 +296,35 @@ Rectangle {
         game2048Controller.setGameOver(false);
     }
 
-    Component.onCompleted: startGame()
+    function restoreGame() {
+        clearAllSlots();
+        var saved = game2048Controller.savedBoard();
+        board = [];
+        for (var i = 0; i < 16; i++)
+            board.push(saved[i]);
+        score = game2048Controller.score;
+        hasWon = game2048Controller.savedHasWon();
+        showWin = false;
+        animating = false;
+        animTimer.stop();
+        for (var j = 0; j < 16; j++) {
+            if (board[j] !== 0) {
+                var slot = acquireSlot(Math.floor(j / 4), j % 4, board[j]);
+                slotMap[j] = slot;
+            }
+        }
+    }
+
+    Component.onCompleted: {
+        if (game2048Controller.hasSavedGame())
+            restoreGame();
+        else
+            startGame();
+    }
+
+    Component.onDestruction: {
+        game2048Controller.saveState(board, hasWon);
+    }
 
     property bool showWin: false
 

--- a/NERODevelopment/src/controllers/game2048controller.cpp
+++ b/NERODevelopment/src/controllers/game2048controller.cpp
@@ -21,6 +21,27 @@ void Game2048Controller::setScore(int score) {
   }
 }
 
+int Game2048Controller::bestScore() const { return m_bestScore; }
+
+void Game2048Controller::setBestScore(int bestScore) {
+  if (bestScore != m_bestScore) {
+    m_bestScore = bestScore;
+    emit bestScoreChanged();
+  }
+}
+
+bool Game2048Controller::hasSavedGame() const { return m_hasSavedGame; }
+
+QVariantList Game2048Controller::savedBoard() const { return m_savedBoard; }
+
+bool Game2048Controller::savedHasWon() const { return m_savedHasWon; }
+
+void Game2048Controller::saveState(const QVariantList &board, bool hasWon) {
+  m_savedBoard = board;
+  m_savedHasWon = hasWon;
+  m_hasSavedGame = true;
+}
+
 void Game2048Controller::enterButtonPressed() {
   if (m_gameOver) {
     emit restartRequested();

--- a/NERODevelopment/src/controllers/game2048controller.h
+++ b/NERODevelopment/src/controllers/game2048controller.h
@@ -3,22 +3,32 @@
 
 #include "buttoncontroller.h"
 #include <QObject>
+#include <QVariantList>
 
 class Game2048Controller : public ButtonController {
   Q_OBJECT
   Q_PROPERTY(bool gameOver READ gameOver WRITE setGameOver NOTIFY
                  gameOverChanged FINAL)
   Q_PROPERTY(int score READ score WRITE setScore NOTIFY scoreChanged FINAL)
+  Q_PROPERTY(int bestScore READ bestScore WRITE setBestScore NOTIFY
+                 bestScoreChanged FINAL)
 
 public:
   explicit Game2048Controller(Model *model, QObject *parent = nullptr);
 
   bool gameOver() const;
   int score() const;
+  int bestScore() const;
+
+  Q_INVOKABLE bool hasSavedGame() const;
+  Q_INVOKABLE QVariantList savedBoard() const;
+  Q_INVOKABLE bool savedHasWon() const;
+  Q_INVOKABLE void saveState(const QVariantList &board, bool hasWon);
 
 public slots:
   void setGameOver(bool gameOver);
   void setScore(int score);
+  void setBestScore(int bestScore);
   void enterButtonPressed() override;
   void upButtonPressed() override;
   void downButtonPressed() override;
@@ -29,12 +39,17 @@ public slots:
 signals:
   void gameOverChanged();
   void scoreChanged();
+  void bestScoreChanged();
   void moveMade(int direction);
   void restartRequested();
 
 private:
   bool m_gameOver = true;
   int m_score = 0;
+  int m_bestScore = 0;
+  QVariantList m_savedBoard;
+  bool m_savedHasWon = false;
+  bool m_hasSavedGame = false;
 };
 
 #endif // GAME2048CONTROLLER_H


### PR DESCRIPTION
## Changes

The 2048 board saves when the user exits and re-enters the game within the same session. The game state was moved onto `Game2048Controller` so it can hold the board across the QML component being unloaded and reloaded by the page Loader. Quitting the app still starts the next launch with a fresh game.

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #228
