### PR TITLE
launch/traction control indicators

### DIFF
--- a/NERODevelopment/content/CMakeLists.txt
+++ b/NERODevelopment/content/CMakeLists.txt
@@ -49,6 +49,7 @@ qt6_add_qml_module(content
         HomeIcon.qml
         SubMenuIcon.qml
         DoomView.qml
+        StatusIndicator.qml
 
     RESOURCES
         fonts/fonts.txt

--- a/NERODevelopment/content/EnduranceScreen.qml
+++ b/NERODevelopment/content/EnduranceScreen.qml
@@ -56,9 +56,28 @@ Item {
             titleHorizontalCenterOffset: (endurance.width - header.width) / 2
         }
 
+        RowLayout {
+            Layout.row: 1
+            Layout.column: 0
+            Layout.columnSpan: 2
+            Layout.alignment: Qt.AlignHCenter
+            Layout.topMargin: -30
+            spacing: 30
+
+            StatusIndicator {
+                label: "TRACTION CONTROL"
+                active: speedController.tractionControl
+            }
+
+            StatusIndicator {
+                label: "LAUNCH CONTROL"
+                active: speedController.launchControl
+            }
+        }
+
         ColumnLayout {
             id: thermColumn
-            Layout.row: 1
+            Layout.row: 2
             Layout.column: 0
             Layout.leftMargin: endurance.xMargin / 2
             Layout.bottomMargin: endurance.yMargin
@@ -108,7 +127,7 @@ Item {
 
         ColumnLayout {
             id: driveColumn
-            Layout.row: 1
+            Layout.row: 2
             Layout.column: 1
             Layout.bottomMargin: endurance.yMargin
             Layout.fillWidth: true
@@ -144,7 +163,7 @@ Item {
             id: percentColumn
             Layout.row: 0
             Layout.column: 2
-            Layout.rowSpan: 2
+            Layout.rowSpan: 3
             Layout.topMargin: endurance.yMargin
             Layout.rightMargin: endurance.xMargin / 2
             Layout.bottomMargin: endurance.yMargin

--- a/NERODevelopment/content/SpeedMode.qml
+++ b/NERODevelopment/content/SpeedMode.qml
@@ -8,7 +8,6 @@ Item {
     id: speedMode
     anchors.fill: parent
 
-    property bool tractionControlStatus: speedController.tractionControl
     property int packTemp: speedController.packTemp
     property int motorTemp: speedController.motorTemp
     property int maxSpeed: speedController.maxSpeed
@@ -43,13 +42,20 @@ Item {
             modeTitle: "PERFORMANCE"
         }
 
-        LabelText {
+        RowLayout {
             Layout.alignment: Qt.AlignHCenter
             Layout.topMargin: -30
-            text: speedMode.tractionControlStatus ? "TRACTION CONTROL - ON" : "TRACTION CONTROL - OFF"
-            color: speedMode.tractionControlStatus ? Theme.goodStatus : Theme.criticalStatus
-            font.pixelSize: 18
-            font.bold: true
+            spacing: 30
+
+            StatusIndicator {
+                label: "TRACTION CONTROL"
+                active: speedController.tractionControl
+            }
+
+            StatusIndicator {
+                label: "LAUNCH CONTROL"
+                active: speedController.launchControl
+            }
         }
 
         RowLayout {

--- a/NERODevelopment/content/StatusIndicator.qml
+++ b/NERODevelopment/content/StatusIndicator.qml
@@ -1,0 +1,12 @@
+import QtQuick
+import QtQuick.Controls
+import NERO
+
+LabelText {
+    property string label: ""
+    property bool active: false
+    text: label + (active ? " - ON" : " - OFF")
+    color: active ? Theme.goodStatus : Theme.criticalStatus
+    font.pixelSize: 18
+    font.bold: true
+}

--- a/NERODevelopment/src/controllers/endurancecontroller.cpp
+++ b/NERODevelopment/src/controllers/endurancecontroller.cpp
@@ -35,7 +35,8 @@ float EnduranceController::currentRegenPercentage() const {
   if (dcCurrent && *dcCurrent < 0 && std::abs(m_maxRegenCapacity) > 0) {
     float percent =
         std::abs(*dcCurrent) / std::abs(m_maxRegenCapacity) * 100.0f;
-    if (percent > 100.0f) percent = 100.0f;
+    if (percent > 100.0f)
+      percent = 100.0f;
     return percent;
   }
   return 0.0f;

--- a/NERODevelopment/src/controllers/speedcontroller.cpp
+++ b/NERODevelopment/src/controllers/speedcontroller.cpp
@@ -14,6 +14,14 @@ void SpeedController::setTractionControl(bool tractionStatus) {
   }
 }
 
+bool SpeedController::launchControl() const { return m_launchControl; }
+void SpeedController::setLaunchControl(bool launchStatus) {
+  if (launchStatus != m_launchControl) {
+    m_launchControl = launchStatus;
+    emit launchControlChanged(launchStatus);
+  }
+}
+
 float SpeedController::regen() const { return m_regen; }
 void SpeedController::setRegen(float regen) {
   if (regen != m_regen) {
@@ -28,7 +36,8 @@ float SpeedController::regenPercentage() const {
   if (dcCurrent && *dcCurrent < 0 && std::abs(m_maxRegenCapacity) > 0) {
     float percent =
         std::abs(*dcCurrent) / std::abs(m_maxRegenCapacity) * 100.0f;
-    if (percent > 100.0f) percent = 100.0f;
+    if (percent > 100.0f)
+      percent = 100.0f;
     return percent;
   }
   return 0.0f;
@@ -131,6 +140,7 @@ void SpeedController::rightButtonPressed() {
 
 void SpeedController::update() {
   setTractionControl(*m_model->getTractionControl());
+  setLaunchControl(*m_model->getLaunchControl());
   setPackTemp(*m_model->getPackTemp());
   setMotorTemp(*m_model->getMotorTemp());
   setChargeState(*m_model->getStateOfCharge());

--- a/NERODevelopment/src/controllers/speedcontroller.h
+++ b/NERODevelopment/src/controllers/speedcontroller.h
@@ -9,6 +9,8 @@ class SpeedController : public ButtonController {
   Q_OBJECT
   Q_PROPERTY(bool tractionControl READ tractionControl WRITE setTractionControl
                  NOTIFY tractionControlChanged)
+  Q_PROPERTY(bool launchControl READ launchControl WRITE setLaunchControl NOTIFY
+                 launchControlChanged)
   Q_PROPERTY(
       float packTemp READ packTemp WRITE setPackTemp NOTIFY packTempChanged)
   Q_PROPERTY(
@@ -27,8 +29,8 @@ class SpeedController : public ButtonController {
                  setCurrentDischarge NOTIFY currentDischargeChanged)
   Q_PROPERTY(float maxCurrentDischarge READ maxCurrentDischarge WRITE
                  setMaxCurrentDischarge NOTIFY maxCurrentDischargeChanged)
-  Q_PROPERTY(float regenPercentage READ regenPercentage NOTIFY
-                 regenPercentageChanged)
+  Q_PROPERTY(
+      float regenPercentage READ regenPercentage NOTIFY regenPercentageChanged)
   Q_PROPERTY(float maxRegenCapacity READ maxRegenCapacity WRITE
                  setMaxRegenCapacity NOTIFY maxRegenCapacityChanged)
   Q_PROPERTY(int powerDrawPercent READ powerDrawPercent WRITE
@@ -40,6 +42,7 @@ public:
   explicit SpeedController(Model *model, QObject *parent = nullptr);
 
   bool tractionControl() const;
+  bool launchControl() const;
   float packTemp() const;
   float motorTemp() const;
   float chargeState() const;
@@ -57,6 +60,7 @@ public:
 
 signals:
   void tractionControlChanged(bool);
+  void launchControlChanged(bool);
   void packTempChanged(float);
   void motorTempChanged(float);
   void chargeStateChanged(float);
@@ -75,6 +79,7 @@ signals:
 
 public slots:
   void setTractionControl(bool);
+  void setLaunchControl(bool);
   void setPackTemp(float);
   void setMotorTemp(float);
   void setChargeState(float);
@@ -95,6 +100,7 @@ public slots:
 
 private:
   bool m_tractionControl = false;
+  bool m_launchControl = false;
   float m_packTemp = 0;
   float m_motorTemp = 0;
   float m_chargeState = 0;

--- a/NERODevelopment/src/models/model.h
+++ b/NERODevelopment/src/models/model.h
@@ -50,6 +50,7 @@ public:
   virtual std::optional<float> getAveCellVoltage() = 0;
   virtual std::optional<float> getCellDelta() = 0;
   virtual std::optional<float> getTractionControl() = 0;
+  virtual std::optional<float> getLaunchControl() = 0;
   virtual std::optional<float> getInverterTemp() = 0;
   virtual std::optional<float> getMotorPower() = 0;
   virtual std::optional<float> getFanPower() = 0;

--- a/NERODevelopment/src/models/raspberry_model.cpp
+++ b/NERODevelopment/src/models/raspberry_model.cpp
@@ -63,6 +63,7 @@ void RaspberryModel::connectToMQTT() {
       AVECELLTEMP,
       AVECELLVOLTAGE,
       TRACTIONCONTROL,
+      LAUNCHCONTROL,
       INVERTERTEMP,
       BMSSTATE,
       BMSFAULT,
@@ -333,6 +334,10 @@ std::optional<float> RaspberryModel::getRegenPower() {
 
 std::optional<float> RaspberryModel::getTractionControl() {
   return this->getById(TRACTIONCONTROL);
+}
+
+std::optional<float> RaspberryModel::getLaunchControl() {
+  return this->getById(LAUNCHCONTROL);
 }
 
 QList<QString> RaspberryModel::getBmsFault() {

--- a/NERODevelopment/src/models/raspberry_model.h
+++ b/NERODevelopment/src/models/raspberry_model.h
@@ -51,6 +51,7 @@ public:
   std::optional<float> getAveCellVoltage() override;
   std::optional<float> getCellDelta() override;
   std::optional<float> getTractionControl() override;
+  std::optional<float> getLaunchControl() override;
   std::optional<float> getInverterTemp() override;
   std::optional<float> getMotorPower() override;
   std::optional<float> getFanPower() override;


### PR DESCRIPTION
## Changes

Added launch control based on the existing traction control indicator. Created a `StatusIndicator.qml` atom so the front end component lives in one place and is implemented in both the performance screen and the endurance screen.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline at end of file warnings
- [ ] All code follows repository-configured prettier formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots of UI changes (see Screenshots section)
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #233 
