### PR TITLE
Headless QML screen capture tool

### DIFF
--- a/NERODevelopment/CMakeLists.txt
+++ b/NERODevelopment/CMakeLists.txt
@@ -88,6 +88,7 @@ set(PROJECT_SOURCES
     src/utils/server_data.h
     src/utils/attributestatus.h
     src/utils/descriptioninfo.h
+    src/utils/screenshottool.h
 
     # Implementation - Controllers
     src/controllers/endurancecontroller.cpp
@@ -115,6 +116,7 @@ set(PROJECT_SOURCES
     # Implementation - Utils
     src/utils/server_data.cpp
     src/utils/descriptioninfo.cpp
+    src/utils/screenshottool.cpp
 
     # Main
     src/main.cpp

--- a/NERODevelopment/src/controllers/navigationcontroller.cpp
+++ b/NERODevelopment/src/controllers/navigationcontroller.cpp
@@ -108,14 +108,21 @@ QVariantList NavigationController::getChildrenOf(int parent) const {
   return list;
 }
 
-void NavigationController::jumpToPage(const QString &label) {
+// Dev testing only for now, drives the screenshot harness
+bool NavigationController::jumpToPage(const QString &label) {
+  // HOME is the menu screen, not a menu entry, so it needs goHome
+  if (label.compare("HOME", Qt::CaseInsensitive) == 0) {
+    goHome();
+    return true;
+  }
   for (int i : Menu::topLevelIndices()) {
     if (Menu::label(i).compare(label, Qt::CaseInsensitive) == 0) {
       setSelectedIndex(i);
       activate();
-      return;
+      return true;
     }
   }
+  return false;
 }
 
 void NavigationController::moveNext() {

--- a/NERODevelopment/src/controllers/navigationcontroller.cpp
+++ b/NERODevelopment/src/controllers/navigationcontroller.cpp
@@ -106,6 +106,16 @@ QVariantList NavigationController::getChildrenOf(int parent) const {
   return list;
 }
 
+void NavigationController::jumpToPage(const QString &label) {
+  for (int i : Menu::topLevelIndices()) {
+    if (Menu::label(i).compare(label, Qt::CaseInsensitive) == 0) {
+      setSelectedIndex(i);
+      activate();
+      return;
+    }
+  }
+}
+
 void NavigationController::moveNext() {
   int pos = m_navOrder.indexOf(m_selected);
   if (pos + 1 < m_navOrder.size()) {

--- a/NERODevelopment/src/controllers/navigationcontroller.h
+++ b/NERODevelopment/src/controllers/navigationcontroller.h
@@ -106,8 +106,8 @@ public:
   Q_INVOKABLE QVariantList getTopLevelItems() const;
   Q_INVOKABLE QVariantList getChildrenOf(int parent) const;
 
-  // Jump straight to a top-level page by label (screenshot harness).
-  Q_INVOKABLE void jumpToPage(const QString &label);
+  // Jump to a top-level page or HOME by label, dev screenshot harness only
+  Q_INVOKABLE bool jumpToPage(const QString &label);
 
   void collapse();
 

--- a/NERODevelopment/src/controllers/navigationcontroller.h
+++ b/NERODevelopment/src/controllers/navigationcontroller.h
@@ -106,6 +106,9 @@ public:
   Q_INVOKABLE QVariantList getTopLevelItems() const;
   Q_INVOKABLE QVariantList getChildrenOf(int parent) const;
 
+  // Jump straight to a top-level page by label (screenshot harness).
+  Q_INVOKABLE void jumpToPage(const QString &label);
+
   void collapse();
 
 public slots:

--- a/NERODevelopment/src/main.cpp
+++ b/NERODevelopment/src/main.cpp
@@ -15,11 +15,10 @@
 #include "import_qml_components_plugins.h"
 #include "import_qml_plugins.h"
 #include "models/raspberry_model.h"
+#include "utils/screenshottool.h"
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
-#include <QQuickWindow>
-#include <QTimer>
 
 int main(int argc, char *argv[]) {
   set_qt_environment();
@@ -83,23 +82,8 @@ int main(int argc, char *argv[]) {
       []() { QCoreApplication::exit(-1); }, Qt::QueuedConnection);
   engine.loadFromModule("content", "App");
 
-  // Screenshot the named page headless, then quit.
-  if (qEnvironmentVariableIsSet("NERO_SCREENSHOT")) {
-    // Read env in the callback; captured locals would dangle.
-    QTimer::singleShot(2000, [&]() { // wait for data + UI
-      navigationController.jumpToPage(qEnvironmentVariable("NERO_SCREENSHOT"));
-      QTimer::singleShot(500, [&]() { // wait for the page to render
-        const QString out =
-            qEnvironmentVariable("NERO_SCREENSHOT_OUT", "shot.png");
-        if (auto *w = qobject_cast<QQuickWindow *>(
-                engine.rootObjects().constFirst())) {
-          const bool ok = w->grabWindow().save(out);
-          qInfo() << "NERO_SCREENSHOT:" << (ok ? "saved" : "FAILED") << out;
-        }
-        QCoreApplication::quit();
-      });
-    });
-  }
+  // Dev screenshot harness, inert unless its env vars are set
+  ScreenshotTool screenshotTool(&engine, &navigationController);
 
   return app.exec();
 }

--- a/NERODevelopment/src/main.cpp
+++ b/NERODevelopment/src/main.cpp
@@ -18,6 +18,8 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
+#include <QQuickWindow>
+#include <QTimer>
 
 int main(int argc, char *argv[]) {
   set_qt_environment();
@@ -80,6 +82,24 @@ int main(int argc, char *argv[]) {
       &engine, &QQmlApplicationEngine::objectCreationFailed, &app,
       []() { QCoreApplication::exit(-1); }, Qt::QueuedConnection);
   engine.loadFromModule("content", "App");
+
+  // Screenshot the named page headless, then quit.
+  if (qEnvironmentVariableIsSet("NERO_SCREENSHOT")) {
+    // Read env in the callback; captured locals would dangle.
+    QTimer::singleShot(2000, [&]() { // wait for data + UI
+      navigationController.jumpToPage(qEnvironmentVariable("NERO_SCREENSHOT"));
+      QTimer::singleShot(500, [&]() { // wait for the page to render
+        const QString out =
+            qEnvironmentVariable("NERO_SCREENSHOT_OUT", "shot.png");
+        if (auto *w = qobject_cast<QQuickWindow *>(
+                engine.rootObjects().constFirst())) {
+          const bool ok = w->grabWindow().save(out);
+          qInfo() << "NERO_SCREENSHOT:" << (ok ? "saved" : "FAILED") << out;
+        }
+        QCoreApplication::quit();
+      });
+    });
+  }
 
   return app.exec();
 }

--- a/NERODevelopment/src/utils/screenshottool.cpp
+++ b/NERODevelopment/src/utils/screenshottool.cpp
@@ -86,7 +86,12 @@ void ScreenshotTool::onTriggerFileChanged() {
 
 void ScreenshotTool::capture(const QString &page, const QString &out,
                              bool quitAfter) {
-  m_nav->jumpToPage(page);
+  if (!m_nav->jumpToPage(page)) {
+    qWarning() << "NERO_SCREENSHOT: unknown page" << page;
+    if (quitAfter)
+      QCoreApplication::quit();
+    return;
+  }
   QTimer::singleShot(500, this, [this, out, quitAfter]() { // let it render
     grabAndSave(out, quitAfter);
   });

--- a/NERODevelopment/src/utils/screenshottool.cpp
+++ b/NERODevelopment/src/utils/screenshottool.cpp
@@ -24,15 +24,40 @@ ScreenshotTool::ScreenshotTool(QQmlApplicationEngine *engine,
   }
 
   // Capture on demand each time the trigger file is written
-  m_triggerPath = qEnvironmentVariable("NERO_SCREENSHOT_WATCH");
-  if (!m_triggerPath.isEmpty()) {
-    if (!QFile::exists(m_triggerPath))
-      QFile(m_triggerPath).open(QIODevice::WriteOnly); // watcher needs a file
-    if (!m_watcher.addPath(m_triggerPath))
-      qWarning() << "NERO_SCREENSHOT_WATCH: cannot watch" << m_triggerPath;
-    connect(&m_watcher, &QFileSystemWatcher::fileChanged, this,
-            &ScreenshotTool::onTriggerFileChanged);
+  if (qEnvironmentVariableIsSet("NERO_SCREENSHOT_WATCH"))
+    setupWatch();
+}
+
+void ScreenshotTool::setupWatch() {
+  m_triggerPath =
+      qEnvironmentVariable("NERO_SCREENSHOT_WATCH_PATH", "/tmp/nero-shot");
+
+  // Fail loudly instead of doing nothing when the path is unusable
+  const QFileInfo info(m_triggerPath);
+  if (info.isDir()) {
+    qWarning() << "NERO_SCREENSHOT_WATCH_PATH is a directory, need a file path"
+               << m_triggerPath;
+    return;
   }
+  if (!info.dir().exists()) {
+    qWarning() << "NERO_SCREENSHOT_WATCH_PATH directory does not exist"
+               << info.dir().absolutePath();
+    return;
+  }
+  if (!QFile::exists(m_triggerPath) &&
+      !QFile(m_triggerPath)
+           .open(QIODevice::WriteOnly)) { // watcher needs a file
+    qWarning() << "NERO_SCREENSHOT_WATCH_PATH cannot create trigger file"
+               << m_triggerPath;
+    return;
+  }
+  if (!m_watcher.addPath(m_triggerPath)) {
+    qWarning() << "NERO_SCREENSHOT_WATCH_PATH cannot watch" << m_triggerPath;
+    return;
+  }
+  connect(&m_watcher, &QFileSystemWatcher::fileChanged, this,
+          &ScreenshotTool::onTriggerFileChanged);
+  qInfo() << "NERO_SCREENSHOT_WATCH: watching" << m_triggerPath;
 }
 
 void ScreenshotTool::onTriggerFileChanged() {

--- a/NERODevelopment/src/utils/screenshottool.cpp
+++ b/NERODevelopment/src/utils/screenshottool.cpp
@@ -103,6 +103,8 @@ void ScreenshotTool::grabAndSave(const QString &out, bool quitAfter) {
                                 : qobject_cast<QQuickWindow *>(roots.first())) {
     const bool ok = w->grabWindow().save(out);
     qInfo() << "NERO_SCREENSHOT:" << (ok ? "saved" : "FAILED") << out;
+  } else {
+    qWarning() << "NERO_SCREENSHOT: no root window to grab";
   }
   if (quitAfter)
     QCoreApplication::quit();

--- a/NERODevelopment/src/utils/screenshottool.cpp
+++ b/NERODevelopment/src/utils/screenshottool.cpp
@@ -1,0 +1,79 @@
+#include "screenshottool.h"
+
+#include "../controllers/navigationcontroller.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QQmlApplicationEngine>
+#include <QQuickWindow>
+#include <QTextStream>
+#include <QTimer>
+
+ScreenshotTool::ScreenshotTool(QQmlApplicationEngine *engine,
+                               NavigationController *nav, QObject *parent)
+    : QObject(parent), m_engine(engine), m_nav(nav) {
+  // Capture the named page once, then quit
+  if (qEnvironmentVariableIsSet("NERO_SCREENSHOT")) {
+    const QString page = qEnvironmentVariable("NERO_SCREENSHOT");
+    const QString out = qEnvironmentVariable("NERO_SCREENSHOT_OUT", "shot.png");
+    QTimer::singleShot(2000, this, [this, page, out]() { // wait for data + UI
+      capture(page, out, /*quitAfter=*/true);
+    });
+  }
+
+  // Capture on demand each time the trigger file is written
+  m_triggerPath = qEnvironmentVariable("NERO_SCREENSHOT_WATCH");
+  if (!m_triggerPath.isEmpty()) {
+    if (!QFile::exists(m_triggerPath))
+      QFile(m_triggerPath).open(QIODevice::WriteOnly); // watcher needs a file
+    if (!m_watcher.addPath(m_triggerPath))
+      qWarning() << "NERO_SCREENSHOT_WATCH: cannot watch" << m_triggerPath;
+    connect(&m_watcher, &QFileSystemWatcher::fileChanged, this,
+            &ScreenshotTool::onTriggerFileChanged);
+  }
+}
+
+void ScreenshotTool::onTriggerFileChanged() {
+  // Re-arm because editors replace the file on save and drop the watch
+  if (!m_watcher.files().contains(m_triggerPath))
+    m_watcher.addPath(m_triggerPath);
+
+  QFile f(m_triggerPath);
+  if (!f.open(QIODevice::ReadOnly))
+    return;
+  // QTextStream detects BOMs so Windows PowerShell writes parse too
+  const QStringList request =
+      QTextStream(&f).readAll().trimmed().split(' ', Qt::SkipEmptyParts);
+  f.close();
+  if (request.isEmpty()) // the truncation below re-fires into this branch
+    return;
+  f.open(QIODevice::WriteOnly); // truncate so the same page can re-fire
+
+  const QString page = request.first();
+  const QString out =
+      request.size() > 1
+          ? request.at(1)
+          : QFileInfo(m_triggerPath).dir().filePath(page.toLower() + ".png");
+  capture(page, out, /*quitAfter=*/false);
+}
+
+void ScreenshotTool::capture(const QString &page, const QString &out,
+                             bool quitAfter) {
+  m_nav->jumpToPage(page);
+  QTimer::singleShot(500, this, [this, out, quitAfter]() { // let it render
+    grabAndSave(out, quitAfter);
+  });
+}
+
+void ScreenshotTool::grabAndSave(const QString &out, bool quitAfter) {
+  const QList<QObject *> roots = m_engine->rootObjects();
+  if (auto *w = roots.isEmpty() ? nullptr
+                                : qobject_cast<QQuickWindow *>(roots.first())) {
+    const bool ok = w->grabWindow().save(out);
+    qInfo() << "NERO_SCREENSHOT:" << (ok ? "saved" : "FAILED") << out;
+  }
+  if (quitAfter)
+    QCoreApplication::quit();
+}

--- a/NERODevelopment/src/utils/screenshottool.h
+++ b/NERODevelopment/src/utils/screenshottool.h
@@ -11,7 +11,8 @@ class NavigationController;
  * @brief The ScreenshotTool class
  * Dev screenshot harness, inert unless its env vars are set
  * One-shot capture via NERO_SCREENSHOT and NERO_SCREENSHOT_OUT
- * On-demand capture via a NERO_SCREENSHOT_WATCH trigger file
+ * On-demand capture enabled by NERO_SCREENSHOT_WATCH, trigger file path
+ * from NERO_SCREENSHOT_WATCH_PATH (defaults to /tmp/nero-shot)
  */
 class ScreenshotTool : public QObject {
   Q_OBJECT
@@ -24,6 +25,7 @@ public:
   void capture(const QString &page, const QString &out, bool quitAfter);
 
 private:
+  void setupWatch();
   void onTriggerFileChanged();
   void grabAndSave(const QString &out, bool quitAfter);
 

--- a/NERODevelopment/src/utils/screenshottool.h
+++ b/NERODevelopment/src/utils/screenshottool.h
@@ -1,0 +1,36 @@
+#ifndef SCREENSHOTTOOL_H
+#define SCREENSHOTTOOL_H
+
+#include <QFileSystemWatcher>
+#include <QObject>
+
+class QQmlApplicationEngine;
+class NavigationController;
+
+/**
+ * @brief The ScreenshotTool class
+ * Dev screenshot harness, inert unless its env vars are set
+ * One-shot capture via NERO_SCREENSHOT and NERO_SCREENSHOT_OUT
+ * On-demand capture via a NERO_SCREENSHOT_WATCH trigger file
+ */
+class ScreenshotTool : public QObject {
+  Q_OBJECT
+
+public:
+  ScreenshotTool(QQmlApplicationEngine *engine, NavigationController *nav,
+                 QObject *parent = nullptr);
+
+  // Navigate to a top-level page and save it as a PNG
+  void capture(const QString &page, const QString &out, bool quitAfter);
+
+private:
+  void onTriggerFileChanged();
+  void grabAndSave(const QString &out, bool quitAfter);
+
+  QQmlApplicationEngine *m_engine;
+  NavigationController *m_nav;
+  QFileSystemWatcher m_watcher;
+  QString m_triggerPath;
+};
+
+#endif // SCREENSHOTTOOL_H

--- a/readme.md
+++ b/readme.md
@@ -120,6 +120,33 @@ Then, change the option from Build Enviornment to System Enviornment.
 
 Finally, save and run it.
 
+### Headless Screenshots (Dev)
+
+Capture any page as a PNG without a display. Both modes do nothing unless their env vars are set.
+
+Commands are bash. On Windows use Git Bash or the Qt Creator run config.
+
+Capture a single page and exit
+
+```bash
+QT_QPA_PLATFORM=offscreen NERO_SCREENSHOT=PERFORMANCE NERO_SCREENSHOT_OUT=perf.png ./NEROApp
+```
+
+Keep the app running and capture on demand
+
+```bash
+# Start with a trigger file
+NERO_SCREENSHOT_WATCH=/tmp/nero-shot ./NEROApp &
+
+# Saves performance.png next to the trigger file
+echo PERFORMANCE > /tmp/nero-shot
+
+# Optional second word picks the output path
+echo "ENDURANCE /tmp/out.png" > /tmp/nero-shot
+```
+
+Page labels match the top-level menu and are case-insensitive.
+
 ### Testing Out Enviornment Variables (On the Car)
 
 First, ssh into godzilla: `ssh godzilla2@192.168.100.57 password <LINUX SERVER PASSWORD>`

--- a/readme.md
+++ b/readme.md
@@ -135,8 +135,11 @@ QT_QPA_PLATFORM=offscreen NERO_SCREENSHOT=PERFORMANCE NERO_SCREENSHOT_OUT=perf.p
 Keep the app running and capture on demand
 
 ```bash
-# Start with a trigger file
-NERO_SCREENSHOT_WATCH=/tmp/nero-shot ./NEROApp &
+# Enable watch mode, trigger file defaults to /tmp/nero-shot
+NERO_SCREENSHOT_WATCH=1 ./NEROApp &
+
+# Or point it at a specific trigger file
+NERO_SCREENSHOT_WATCH=1 NERO_SCREENSHOT_WATCH_PATH=/tmp/nero-shot ./NEROApp &
 
 # Saves performance.png next to the trigger file
 echo PERFORMANCE > /tmp/nero-shot
@@ -145,7 +148,7 @@ echo PERFORMANCE > /tmp/nero-shot
 echo "ENDURANCE /tmp/out.png" > /tmp/nero-shot
 ```
 
-Page labels match the top-level menu and are case-insensitive.
+Page labels match the top-level menu and are case-insensitive. Use HOME to capture the menu screen.
 
 ### Testing Out Enviornment Variables (On the Car)
 


### PR DESCRIPTION
## Changes

Adds a headless screenshot mode for development. Setting NERO_SCREENSHOT to a page name launches the app, saves that page as a PNG, and exits. Normal runtime is unchanged.

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #242
