### PR TITLE
Remove Qt5Compat dependency

### DIFF
--- a/NERODevelopment/content/DescriptionModal.qml
+++ b/NERODevelopment/content/DescriptionModal.qml
@@ -1,6 +1,6 @@
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
+import QtQuick.Effects
 import NERO
 
 Rectangle {
@@ -35,11 +35,10 @@ Rectangle {
             fillMode: Image.PreserveAspectCrop
 
             layer.enabled: true
-            layer.effect: OpacityMask {
-                maskSource: Item {
-                    width: modalPic.width
-                    height: modalPic.height
-                    Rectangle {
+            layer.effect: MultiEffect {
+                maskEnabled: true
+                maskSource: ShaderEffectSource {
+                    sourceItem: Rectangle {
                         width: modalPic.width
                         height: modalPic.height
                         radius: modalPic.radius


### PR DESCRIPTION
## Changes

Removes the legacy Qt5Compat.GraphicalEffects import. Its only use was a single OpacityMask rounding the logo in DescriptionModal, now replaced with the Qt6 successor MultiEffect from QtQuick.Effects.

## Checklist

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #246
