### PR TITLE
#251 add VCU state readout to nav home page header

### DIFF
--- a/NERODevelopment/CMakeLists.txt
+++ b/NERODevelopment/CMakeLists.txt
@@ -59,6 +59,7 @@ set_source_files_properties(${DOOM_SOURCES} PROPERTIES COMPILE_FLAGS "-w")
 set(PROJECT_SOURCES
     # Headers - Constants
     src/constants/fault_statuses.h
+    src/constants/vcu_state_labels.h
 
     # Headers - Controllers
     src/controllers/chargingcontroller.h

--- a/NERODevelopment/content/CMakeLists.txt
+++ b/NERODevelopment/content/CMakeLists.txt
@@ -49,6 +49,7 @@ qt6_add_qml_module(content
         HomeIcon.qml
         SubMenuIcon.qml
         DoomView.qml
+        VcuStateComponent.qml
 
     RESOURCES
         fonts/fonts.txt

--- a/NERODevelopment/content/NavigationController.qml
+++ b/NERODevelopment/content/NavigationController.qml
@@ -48,6 +48,19 @@ Item {
         color: navigationController.isTsOn ? Theme.goodStatus : Theme.criticalStatus
     }
 
+    VcuStateComponent {
+        id: vcuStateComponent
+        anchors {
+            top: parent.top
+            topMargin: parent.height * 0.01
+            left: parent.left
+            leftMargin: parent.width * 0.61
+            right: parent.right
+            rightMargin: parent.width * 0.05
+        }
+        visible: !navigationController.isPageActive
+    }
+
     ColumnLayout {
         id: navContainer
         anchors {

--- a/NERODevelopment/content/VcuStateComponent.qml
+++ b/NERODevelopment/content/VcuStateComponent.qml
@@ -15,7 +15,36 @@ Item {
     readonly property bool rejected: navigationController ? navigationController.stateRejectionActive : false
     readonly property var rejectionReasons: navigationController ? navigationController.stateRejectionReasons : []
 
-    readonly property string reasonText: root.rejectionReasons.join("  |  ")
+    readonly property int reasonFontSize: 14
+    readonly property int reasonLineCount: 2
+    readonly property string reasonSeparator: "  |  "
+
+    readonly property string reasonText: {
+        const all = root.rejectionReasons;
+        if (all.length === 0)
+            return "";
+        const budget = root.width * root.reasonLineCount;
+        let shown = all[0];
+        let count = 1;
+        while (count < all.length) {
+            const merged = shown + root.reasonSeparator + all[count];
+            const hidden = all.length - count - 1;
+            const trial = hidden > 0 ? merged + root.reasonSeparator + "+" + hidden : merged;
+            if (reasonMetrics.advanceWidth(trial) > budget)
+                break;
+            shown = merged;
+            count += 1;
+        }
+        if (count === all.length)
+            return shown;
+        return shown + root.reasonSeparator + "+" + (all.length - count);
+    }
+
+    FontMetrics {
+        id: reasonMetrics
+        font.family: webFont.name
+        font.pixelSize: root.reasonFontSize
+    }
 
     implicitHeight: reasonLine.visible ? reasonLine.y + reasonLine.height : stateText.height
 
@@ -38,9 +67,10 @@ Item {
         width: parent.width
         horizontalAlignment: Text.AlignRight
         elide: Text.ElideRight
-        wrapMode: Text.NoWrap
+        wrapMode: Text.WordWrap
+        maximumLineCount: 2
         text: root.reasonText
-        font.pixelSize: 14
+        font.pixelSize: root.reasonFontSize
         color: root.cautionColor
         visible: root.rejected
     }

--- a/NERODevelopment/content/VcuStateComponent.qml
+++ b/NERODevelopment/content/VcuStateComponent.qml
@@ -11,7 +11,6 @@ Item {
 
     readonly property string stateLabel: navigationController ? navigationController.functionalStateLabel : ""
     readonly property bool stateKnown: navigationController ? navigationController.functionalStateKnown : false
-    readonly property bool stateActive: navigationController ? navigationController.functionalStateActive : false
     readonly property bool stateFaulted: navigationController ? navigationController.functionalStateFaulted : false
     readonly property bool rejected: navigationController ? navigationController.stateRejectionActive : false
     readonly property var rejectionReasons: navigationController ? navigationController.stateRejectionReasons : []
@@ -29,7 +28,7 @@ Item {
         elide: Text.ElideRight
         text: root.stateLabel
         font.pixelSize: 20
-        color: root.stateFaulted ? root.faultColor : root.rejected ? root.cautionColor : root.stateActive ? root.activeColor : root.stateKnown ? root.cautionColor : root.absentColor
+        color: root.stateFaulted ? root.faultColor : root.rejected ? root.cautionColor : root.stateKnown ? root.activeColor : root.absentColor
     }
 
     LabelText {

--- a/NERODevelopment/content/VcuStateComponent.qml
+++ b/NERODevelopment/content/VcuStateComponent.qml
@@ -1,0 +1,48 @@
+import QtQuick
+import NERO
+
+Item {
+    id: root
+
+    readonly property color absentColor: Theme.mutedForeground
+    readonly property color activeColor: Theme.goodStatus
+    readonly property color cautionColor: Theme.cautionStatus
+    readonly property color faultColor: Theme.criticalStatus
+
+    readonly property string stateLabel: navigationController ? navigationController.functionalStateLabel : ""
+    readonly property bool stateKnown: navigationController ? navigationController.functionalStateKnown : false
+    readonly property bool stateActive: navigationController ? navigationController.functionalStateActive : false
+    readonly property bool stateFaulted: navigationController ? navigationController.functionalStateFaulted : false
+    readonly property bool rejected: navigationController ? navigationController.stateRejectionActive : false
+    readonly property var rejectionReasons: navigationController ? navigationController.stateRejectionReasons : []
+
+    readonly property string reasonText: root.rejectionReasons.join("  |  ")
+
+    implicitHeight: reasonLine.visible ? reasonLine.y + reasonLine.height : stateText.height
+
+    LabelText {
+        id: stateText
+        anchors.right: parent.right
+        y: 0
+        width: parent.width
+        horizontalAlignment: Text.AlignRight
+        elide: Text.ElideRight
+        text: root.stateLabel
+        font.pixelSize: 20
+        color: root.stateFaulted ? root.faultColor : root.rejected ? root.cautionColor : root.stateActive ? root.activeColor : root.stateKnown ? root.cautionColor : root.absentColor
+    }
+
+    LabelText {
+        id: reasonLine
+        anchors.right: parent.right
+        y: 19
+        width: parent.width
+        horizontalAlignment: Text.AlignRight
+        elide: Text.ElideRight
+        wrapMode: Text.NoWrap
+        text: root.reasonText
+        font.pixelSize: 14
+        color: root.cautionColor
+        visible: root.rejected
+    }
+}

--- a/NERODevelopment/src/constants/vcu_state_labels.h
+++ b/NERODevelopment/src/constants/vcu_state_labels.h
@@ -89,20 +89,6 @@ inline bool functionalStateIsKnown(std::optional<int> wire) {
   return carStateLookup(FUNCTIONAL_STATE_LABELS, wire).has_value();
 }
 
-inline bool functionalStateIsActive(std::optional<int> wire) {
-  if (!wire.has_value() || !functionalStateIsKnown(wire))
-    return false;
-  switch (static_cast<FunctionalState>(*wire)) {
-  case FunctionalState::Pit:
-  case FunctionalState::Reverse:
-  case FunctionalState::Performance:
-  case FunctionalState::Efficiency:
-    return true;
-  default:
-    return false;
-  }
-}
-
 inline bool functionalStateIsFaulted(std::optional<int> wire) {
   if (!wire.has_value() || !functionalStateIsKnown(wire))
     return false;

--- a/NERODevelopment/src/constants/vcu_state_labels.h
+++ b/NERODevelopment/src/constants/vcu_state_labels.h
@@ -1,0 +1,129 @@
+#ifndef VCU_STATE_LABELS_H
+#define VCU_STATE_LABELS_H
+
+#include <QList>
+#include <QString>
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <optional>
+
+#define CAR_STATE_ABSENT_LABEL "NO VCU"
+#define CAR_STATE_INVALID_LABEL "INVALID"
+#define CAR_STATE_UNKNOWN_REASON_LABEL "UNKNOWN REASON"
+#define STATE_REJECTION_KNOWN_BITS 0x7F
+
+enum class FunctionalState : int {
+  Ready = 0,
+  Pit = 1,
+  Reverse = 2,
+  Performance = 3,
+  Efficiency = 4,
+  Faulted = 5,
+};
+
+enum class StateRejectionError : int {
+  ReverseDisabled = 1 << 0,
+  DriveFromFault = 1 << 1,
+  EnterDriveShutdownOpen = 1 << 2,
+  EnterDriveBrakesNotEngaged = 1 << 3,
+  EnterGamesShutdownClosed = 1 << 4,
+  EnterGamesWhileMoving = 1 << 5,
+  ChangeStateAccelPressed = 1 << 6,
+};
+
+struct CarStateLabel {
+  int value;
+  const char *label;
+};
+
+inline constexpr std::array<CarStateLabel, 6> FUNCTIONAL_STATE_LABELS = {
+    {{static_cast<int>(FunctionalState::Ready), "READY"},
+     {static_cast<int>(FunctionalState::Pit), "PIT"},
+     {static_cast<int>(FunctionalState::Reverse), "REVERSE"},
+     {static_cast<int>(FunctionalState::Performance), "PERFORMANCE"},
+     {static_cast<int>(FunctionalState::Efficiency), "EFFICIENCY"},
+     {static_cast<int>(FunctionalState::Faulted), "FAULTED"}}};
+
+inline constexpr std::array<CarStateLabel, 7> STATE_REJECTION_LABELS = {
+    {{static_cast<int>(StateRejectionError::ReverseDisabled), "NO REV"},
+     {static_cast<int>(StateRejectionError::DriveFromFault), "CLR FAULT"},
+     {static_cast<int>(StateRejectionError::EnterDriveShutdownOpen), "SD OPEN"},
+     {static_cast<int>(StateRejectionError::EnterDriveBrakesNotEngaged),
+      "NO BRAKE"},
+     {static_cast<int>(StateRejectionError::EnterGamesShutdownClosed),
+      "SD CLOSED"},
+     {static_cast<int>(StateRejectionError::EnterGamesWhileMoving),
+      "CAR MOVING"},
+     {static_cast<int>(StateRejectionError::ChangeStateAccelPressed),
+      "REL ACCEL"}}};
+
+inline std::optional<int> carStateWireValue(std::optional<float> raw) {
+  if (!raw.has_value() || !std::isfinite(*raw))
+    return std::nullopt;
+  return static_cast<int>(std::clamp(*raw, -1000.0f, 1000.0f));
+}
+
+template <std::size_t N>
+inline std::optional<QString>
+carStateLookup(const std::array<CarStateLabel, N> &table,
+               std::optional<int> wire) {
+  if (!wire.has_value())
+    return std::nullopt;
+  for (const CarStateLabel &entry : table) {
+    if (entry.value == *wire)
+      return QString::fromUtf8(entry.label);
+  }
+  return std::nullopt;
+}
+
+inline QString functionalStateText(std::optional<int> wire) {
+  if (!wire.has_value())
+    return QStringLiteral(CAR_STATE_ABSENT_LABEL);
+  return carStateLookup(FUNCTIONAL_STATE_LABELS, wire)
+      .value_or(QStringLiteral(CAR_STATE_INVALID_LABEL));
+}
+
+inline bool functionalStateIsKnown(std::optional<int> wire) {
+  return carStateLookup(FUNCTIONAL_STATE_LABELS, wire).has_value();
+}
+
+inline bool functionalStateIsActive(std::optional<int> wire) {
+  if (!wire.has_value() || !functionalStateIsKnown(wire))
+    return false;
+  switch (static_cast<FunctionalState>(*wire)) {
+  case FunctionalState::Pit:
+  case FunctionalState::Reverse:
+  case FunctionalState::Performance:
+  case FunctionalState::Efficiency:
+    return true;
+  default:
+    return false;
+  }
+}
+
+inline bool functionalStateIsFaulted(std::optional<int> wire) {
+  if (!wire.has_value() || !functionalStateIsKnown(wire))
+    return false;
+  return *wire == static_cast<int>(FunctionalState::Faulted);
+}
+
+inline QList<QString> stateRejectionTexts(std::optional<int> wire) {
+  QList<QString> reasons;
+  if (!wire.has_value() || *wire == 0)
+    return reasons;
+  for (const CarStateLabel &entry : STATE_REJECTION_LABELS) {
+    if (*wire & entry.value)
+      reasons.append(QString::fromUtf8(entry.label));
+  }
+  if (*wire & ~STATE_REJECTION_KNOWN_BITS)
+    reasons.append(QStringLiteral(CAR_STATE_UNKNOWN_REASON_LABEL));
+  return reasons;
+}
+
+inline bool stateRejectionIsActive(std::optional<int> wire) {
+  return wire.has_value() && *wire != 0;
+}
+
+#endif // VCU_STATE_LABELS_H

--- a/NERODevelopment/src/controllers/navigationcontroller.cpp
+++ b/NERODevelopment/src/controllers/navigationcontroller.cpp
@@ -42,6 +42,8 @@ NavigationController::NavigationController(Model *model, QObject *parent)
   });
   connect(m_model, &Model::onCurrentDataChange, this,
           &NavigationController::syncModeFromVcu);
+  connect(m_model, &Model::onCurrentDataChange, this,
+          &NavigationController::updateCarStateReadout);
   rebuildNavOrder();
 }
 
@@ -250,6 +252,25 @@ void NavigationController::syncModeFromVcu() {
     setActivePage(top);
     break;
   }
+}
+
+void NavigationController::setFunctionalState(std::optional<int> state) {
+  if (m_functionalState == state)
+    return;
+  m_functionalState = state;
+  emit functionalStateChanged();
+}
+
+void NavigationController::setStateRejection(std::optional<int> mask) {
+  if (m_stateRejection == mask)
+    return;
+  m_stateRejection = mask;
+  emit stateRejectionChanged();
+}
+
+void NavigationController::updateCarStateReadout() {
+  setFunctionalState(carStateWireValue(m_model->getFunctionalState()));
+  setStateRejection(carStateWireValue(m_model->getStateRejectionError()));
 }
 
 void NavigationController::buttonUpdate() {

--- a/NERODevelopment/src/controllers/navigationcontroller.h
+++ b/NERODevelopment/src/controllers/navigationcontroller.h
@@ -94,8 +94,6 @@ class NavigationController : public ButtonController {
                  functionalStateChanged)
   Q_PROPERTY(bool functionalStateKnown READ functionalStateKnown NOTIFY
                  functionalStateChanged)
-  Q_PROPERTY(bool functionalStateActive READ functionalStateActive NOTIFY
-                 functionalStateChanged)
   Q_PROPERTY(bool functionalStateFaulted READ functionalStateFaulted NOTIFY
                  functionalStateChanged)
   Q_PROPERTY(QList<QString> stateRejectionReasons READ stateRejectionReasons
@@ -117,9 +115,6 @@ public:
   }
   bool functionalStateKnown() const {
     return functionalStateIsKnown(m_functionalState);
-  }
-  bool functionalStateActive() const {
-    return functionalStateIsActive(m_functionalState);
   }
   bool functionalStateFaulted() const {
     return functionalStateIsFaulted(m_functionalState);

--- a/NERODevelopment/src/controllers/navigationcontroller.h
+++ b/NERODevelopment/src/controllers/navigationcontroller.h
@@ -1,6 +1,7 @@
 #ifndef NAVIGATIONCONTROLLER_H
 #define NAVIGATIONCONTROLLER_H
 
+#include "../constants/vcu_state_labels.h"
 #include "../controllers/buttoncontroller.h"
 #include "../models/model.h"
 
@@ -89,6 +90,18 @@ class NavigationController : public ButtonController {
   Q_PROPERTY(int expandedIndex READ expandedIndex NOTIFY expandedChanged)
   Q_PROPERTY(bool isPageActive READ isPageActive NOTIFY activePageChanged)
   Q_PROPERTY(bool isTsOn READ isTsOn NOTIFY isTsOnChanged)
+  Q_PROPERTY(QString functionalStateLabel READ functionalStateLabel NOTIFY
+                 functionalStateChanged)
+  Q_PROPERTY(bool functionalStateKnown READ functionalStateKnown NOTIFY
+                 functionalStateChanged)
+  Q_PROPERTY(bool functionalStateActive READ functionalStateActive NOTIFY
+                 functionalStateChanged)
+  Q_PROPERTY(bool functionalStateFaulted READ functionalStateFaulted NOTIFY
+                 functionalStateChanged)
+  Q_PROPERTY(QList<QString> stateRejectionReasons READ stateRejectionReasons
+                 NOTIFY stateRejectionChanged)
+  Q_PROPERTY(bool stateRejectionActive READ stateRejectionActive NOTIFY
+                 stateRejectionChanged)
 
 public:
   explicit NavigationController(Model *model, QObject *parent = nullptr);
@@ -98,6 +111,25 @@ public:
   int expandedIndex() const { return m_expanded; }
   bool isPageActive() const { return m_activePage >= 0; }
   bool isTsOn() const { return m_isTsOn; }
+
+  QString functionalStateLabel() const {
+    return functionalStateText(m_functionalState);
+  }
+  bool functionalStateKnown() const {
+    return functionalStateIsKnown(m_functionalState);
+  }
+  bool functionalStateActive() const {
+    return functionalStateIsActive(m_functionalState);
+  }
+  bool functionalStateFaulted() const {
+    return functionalStateIsFaulted(m_functionalState);
+  }
+  QList<QString> stateRejectionReasons() const {
+    return stateRejectionTexts(m_stateRejection);
+  }
+  bool stateRejectionActive() const {
+    return stateRejectionIsActive(m_stateRejection);
+  }
 
   Q_INVOKABLE QString labelFor(int i) const { return Menu::label(i); }
   Q_INVOKABLE QString iconFor(int i) const { return Menu::icon(i); }
@@ -125,6 +157,8 @@ signals:
   void activePageChanged();
   void expandedChanged();
   void isTsOnChanged(bool);
+  void functionalStateChanged();
+  void stateRejectionChanged();
   void themeChanged(const QString &theme);
   void exitRequested();
 
@@ -138,10 +172,16 @@ private:
 
   void syncModeFromVcu();
 
+  void updateCarStateReadout();
+  void setFunctionalState(std::optional<int> state);
+  void setStateRejection(std::optional<int> mask);
+
   int m_selected = 0;
   int m_activePage = -1;
   int m_expanded = -1;
   bool m_isTsOn = false;
+  std::optional<int> m_functionalState;
+  std::optional<int> m_stateRejection;
   int m_lastModeIndex = -999;
   bool m_lastHomeMode = false;
   QVector<int> m_navOrder;

--- a/NERODevelopment/src/models/model.h
+++ b/NERODevelopment/src/models/model.h
@@ -91,6 +91,8 @@ public:
 
   virtual std::optional<bool> getHomeButtonPressed() = 0;
   virtual std::optional<float> getModeIndex() = 0;
+  virtual std::optional<float> getFunctionalState() = 0;
+  virtual std::optional<float> getStateRejectionError() = 0;
   virtual std::optional<float> getGForceX() = 0;
   virtual std::optional<float> getGForceY() = 0;
   virtual std::optional<float> getGForceZ() = 0;

--- a/NERODevelopment/src/models/raspberry_model.cpp
+++ b/NERODevelopment/src/models/raspberry_model.cpp
@@ -97,6 +97,8 @@ void RaspberryModel::connectToMQTT() {
       BUTTONID,
       HOMEBUTTON,
       MODEINDEX,
+      FUNCTIONALSTATE,
+      STATEREJECTIONERROR,
       DIRECTION,
   };
 
@@ -474,6 +476,14 @@ std::optional<bool> RaspberryModel::getHomeButtonPressed() {
 
 std::optional<float> RaspberryModel::getModeIndex() {
   return this->getById(MODEINDEX);
+}
+
+std::optional<float> RaspberryModel::getFunctionalState() {
+  return this->getById(FUNCTIONALSTATE);
+}
+
+std::optional<float> RaspberryModel::getStateRejectionError() {
+  return this->getById(STATEREJECTIONERROR);
 }
 
 void RaspberryModel::updateCurrentData() { emit this->onCurrentDataChange(); }

--- a/NERODevelopment/src/models/raspberry_model.h
+++ b/NERODevelopment/src/models/raspberry_model.h
@@ -86,6 +86,8 @@ public:
 
   std::optional<bool> getHomeButtonPressed() override;
   std::optional<float> getModeIndex() override;
+  std::optional<float> getFunctionalState() override;
+  std::optional<float> getStateRejectionError() override;
   std::optional<float> getGForceX() override;
   std::optional<float> getGForceY() override;
   std::optional<float> getGForceZ() override;

--- a/NERODevelopment/src/utils/data_type_names.h
+++ b/NERODevelopment/src/utils/data_type_names.h
@@ -75,6 +75,8 @@
   "VCU/CarState/nero_index" // '0' = OFF, '1' = PIT, '2' = REVERSE, '3' =
                             // PERFORMANCE, '4' = EFFICIENCY, '5' = GAMES, '6' =
                             // THEMES, '7' = EXIT
+#define FUNCTIONALSTATE "VCU/CarState/functional_state"
+#define STATEREJECTIONERROR "VCU/CarState/state_rejection_error"
 #define MOTORPOWER                                                             \
   "VCU/eFuses/MC/Current" // Current (A) flowing through motor controller eFuse.
 #define FANPOWER                                                               \


### PR DESCRIPTION
## Changes

Adds a debug readout to the right side of the header showing the VCU functional state, with any active state rejection reasons on a second line that only appears while the VCU is refusing a state change. Currently displayed on the nav home page only.

## Screenshots

<img width="779" height="469" alt="Screenshot from 2026-08-01 02-33-06" src="https://github.com/user-attachments/assets/4d755fac-868a-4e00-a365-93576f0569ff" />

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please review the [contributor guide](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/8060929/Software+Contributor+Guide) and reach out to your Tech Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline at end of file warnings
- [x] All code follows repository-configured prettier formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots of UI changes (see Screenshots section)
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #251 
